### PR TITLE
Use raw string literal syntax

### DIFF
--- a/file/file.go
+++ b/file/file.go
@@ -17,7 +17,6 @@ import (
 
 var filenameRegex = `^([0-9]+)_(.*)\.(up|down)\.%s$`
 
-
 // FilenameRegex builds regular expression stmt with given
 // filename extension from driver.
 func FilenameRegex(filenameExtension string) *regexp.Regexp {


### PR DESCRIPTION
Just nitpicking, but this looks much nicer (and less prone to errors) than double backslashes.
