### PR TITLE
Allow protocol and cql versions to be configured via driver path

### DIFF
--- a/driver/cassandra/cassandra.go
+++ b/driver/cassandra/cassandra.go
@@ -2,7 +2,10 @@
 package cassandra
 
 import (
+	"fmt"
 	"net/url"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gocql/gocql"
@@ -18,17 +21,20 @@ const tableName = "schema_migrations"
 const versionRow = 1
 
 // Cassandra Driver URL format:
-// cassandra://host:port/keyspace
+// cassandra://host:port/keyspace[/protocol=2/cql=3.0.5]
 //
 // Example:
 // cassandra://localhost/SpaceOfKeys
 func (driver *Driver) Initialize(rawurl string) error {
 	u, err := url.Parse(rawurl)
+	if err != nil {
+		return err
+	}
 
-	cluster := gocql.NewCluster(u.Host)
-	cluster.Keyspace = u.Path[1:len(u.Path)]
-	cluster.Consistency = gocql.All
-	cluster.Timeout = 1 * time.Minute
+	cluster, err := clusterConfigFromUrl(u)
+	if err != nil {
+		return err
+	}
 
 	driver.session, err = cluster.CreateSession()
 
@@ -40,6 +46,39 @@ func (driver *Driver) Initialize(rawurl string) error {
 		return err
 	}
 	return nil
+}
+
+func clusterConfigFromUrl(u *url.URL) (*gocql.ClusterConfig, error) {
+	// slashes are not valid in keyspace names, so we can use things after
+	// the slash to further configure the connection; we lop off the leading
+	// slash to start things off
+	pathParts := strings.Split(u.Path[1:], "/")
+
+	cluster := gocql.NewCluster(u.Host)
+	cluster.Keyspace = pathParts[0]
+	cluster.Consistency = gocql.All
+	cluster.Timeout = 1 * time.Minute
+
+	for _, part := range pathParts[1:] {
+		kv := strings.Split(part, "=")
+		if len(kv) != 2 {
+			return nil, fmt.Errorf("Invalid cassandra cluster config option %s", part)
+		}
+		key, value := kv[0], kv[1]
+		switch key {
+		case "protocol":
+			numProto, err := strconv.ParseInt(value, 10, 32)
+			if err != nil {
+				return nil, fmt.Errorf("Invalid protocol number: %s (%s)", value, err)
+			}
+			cluster.ProtoVersion = int(numProto)
+		case "cql":
+			cluster.CQLVersion = value
+		default:
+			return nil, fmt.Errorf("Invalid cassandra cluster config option %s", part)
+		}
+	}
+	return cluster, nil
 }
 
 func (driver *Driver) Close() error {

--- a/driver/cassandra/cassandra_test.go
+++ b/driver/cassandra/cassandra_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestClusterConfigFromUrl(t *testing.T) {
-	rawurl := "cassandra://localhos/migratetest/protocol=1/cql=3.0.1"
+	rawurl := "cassandra://localhos/migratetest?protocol=1&cql=3.0.1"
 	u, err := url.Parse(rawurl)
 	if err != nil {
 		t.Fatal(err)
@@ -53,10 +53,10 @@ func TestDefaultsPreserved(t *testing.T) {
 
 func TestInvalidConfigOptions(t *testing.T) {
 	invalids := []string{
-		"cassandra://localhost/migratetest/protocol=a",
-		"cassandra://localhost/migratetest/proto=1/cql=3.0.1",
+		"cassandra://localhost/migratetest?protocol=a",
+		"cassandra://localhost/migratetest?protocol=1?cql=3.0.1",
 		"cassandra://localhost/migratetest/foo=bar",
-		"cassandra://localhost/migratetest/proto/1",
+		"cassandra://localhost/migratetest/proto=1",
 	}
 	for _, rawurl := range invalids {
 		u, err := url.Parse(rawurl)


### PR DESCRIPTION
> In order to be used with Cassandra 1.2.x, the `ProtocolVersion` value
has to be set to 1 (gocql defaults to 2). This patch makes the migrate
code parse additional options out of the url.

> Tests have been added for this new behavior, as well as to verify that
omitting the optional parameters preserves the defaults as is.

Upon getting through this part and actually trying to run a migration, I discovered the next issue: the driver uses `CREATE TABLE IF NOT EXISTS` syntax, which is only valid in CQL 3.1, that is Cassandra 2.x. In order to make it work with 1.x, I'd have to add a conditional around that statement and just do an old fashioned `SELECT` to see if the table exists before proceeding in case the `ProtocolVersion` is set to 1.

Upon coming to this juncture, I started to wonder - should I just add a `cassandra1.2` driver instead of adding the flexibility into the existing `cassandra` driver? I can see arguments both ways, so I figured I'd check in before I wrote a whole bunch more code. It does beg the question of what'll happen when Cassandra 3.x comes out and the `cassandra` driver as named does not work with it.