### PR TITLE
return ok bool instead of error bool

### DIFF
--- a/main.go
+++ b/main.go
@@ -162,7 +162,7 @@ func writePipe(pipe chan interface{}) bool {
 			select {
 			case item, ok := <-pipe:
 				if !ok {
-					return errorFlag
+					return !errorFlag
 				} else {
 					switch item.(type) {
 


### PR DESCRIPTION
fixed #22 

`writePipe` was returning whether or not an error occurred, so the bool represented an error. But in the Migrate commands it was set to an `ok` variable. Which was the opposite of what was returned. I flipped the return on `writePipe` so it now returns a bool representing "ok".
