### PR TITLE
Ensure that interrupt signals are not relayed to the interrupt channel when the migration is over

### DIFF
--- a/pipe/pipe.go
+++ b/pipe/pipe.go
@@ -3,6 +3,7 @@ package pipe
 
 import (
 	"os"
+	"os/signal"
 )
 
 // New creates a new pipe. A pipe is basically a channel.
@@ -25,6 +26,7 @@ func Close(pipe chan interface{}, err error) {
 func WaitAndRedirect(pipe, redirectPipe chan interface{}, interrupt chan os.Signal) (ok bool) {
 	errorReceived := false
 	interruptsReceived := 0
+	defer stopNotifyInterruptChannel(interrupt)
 	if pipe != nil && redirectPipe != nil {
 		for {
 			select {
@@ -74,4 +76,10 @@ func ReadErrors(pipe chan interface{}) []error {
 		}
 	}
 	return err
+}
+
+func stopNotifyInterruptChannel(interruptChannel chan os.Signal) {
+	if interruptChannel != nil {
+		signal.Stop(interruptChannel)
+	}
 }


### PR DESCRIPTION
Hi,

Like I said [here](https://github.com/mattes/migrate/issues/1#issuecomment-58728186), I had a problem interrupting my program when a migration successfully ran. I think the problem was that the interrupt signals were still being relayed to the interrupt channel created in the Up method of migrate.go.

That channel is passed to the WaitAndRedirect function of the Pipe. I added a simple function that is called after the function return to ensure the signals stop being relayed when the migration is over, successful or not.

What do you think? 
P.S. : I ran the test against a MySQL database where and everything was still fine.

Thanks, David
