### PR TITLE
Return okFlag when done reading from the pipe (may fix #24)

### DIFF
--- a/main.go
+++ b/main.go
@@ -162,7 +162,7 @@ func writePipe(pipe chan interface{}) (ok bool) {
 			select {
 			case item, ok := <-pipe:
 				if !ok {
-					return false
+					return okFlag
 				} else {
 					switch item.(type) {
 


### PR DESCRIPTION
The intention seems to be that `writePipe` return false only in case of error, but in fact it returns false any time `pipe` is not nil.  This PR changes `writePipe` to return either true or false according to whether `okFlag` has remained true or not.
