### PR TITLE
ok flag is misleading, it's really if channel is closed, so return okFlag

### DIFF
--- a/main.go
+++ b/main.go
@@ -160,9 +160,9 @@ func writePipe(pipe chan interface{}) (ok bool) {
 	if pipe != nil {
 		for {
 			select {
-			case item, ok := <-pipe:
-				if !ok {
-					return false
+			case item, more := <-pipe:
+				if !more {
+					return okFlag
 				} else {
 					switch item.(type) {
 


### PR DESCRIPTION
the `ok` we fixed last time is actually a signal the pipe is closed. This doesn't mean there is necessarily an error, just that work is done. So, when we get this, we should return the current okFlag value, which lets us know if there were errors during execution.

cheers!