### PR TITLE
Add authentication support for cassandra

### DIFF
--- a/driver/cassandra/cassandra.go
+++ b/driver/cassandra/cassandra.go
@@ -2,13 +2,13 @@
 package cassandra
 
 import (
-	"net/url"
-	"strings"
-	"time"
-
+	"fmt"
 	"github.com/gocql/gocql"
 	"github.com/mattes/migrate/file"
 	"github.com/mattes/migrate/migrate/direction"
+	"net/url"
+	"strings"
+	"time"
 )
 
 type Driver struct {
@@ -49,6 +49,21 @@ func (driver *Driver) Initialize(rawurl string) error {
 	cluster.Keyspace = u.Path[1:len(u.Path)]
 	cluster.Consistency = gocql.All
 	cluster.Timeout = 1 * time.Minute
+
+	// Check if url user struct is null
+	if u.User != nil {
+		password, passwordSet := u.User.Password()
+
+		if passwordSet == false {
+			return fmt.Errorf("Missing password. Please provide password")
+		}
+
+		cluster.Authenticator = gocql.PasswordAuthenticator{
+			Username: u.User.Username(),
+			Password: password,
+		}
+
+	}
 
 	driver.session, err = cluster.CreateSession()
 


### PR DESCRIPTION
Hi, 

This is my first pull request so let me know if I missed anything.

I had issue connecting to cassandra with native authenticator enabled. This pull request enable migrate to work when PasswordAuthenticator is enabled.

How to run..
migrate -url cassandra://username:password@hostname:port/schema_name-path ./cassandramigrations create init

Documentations url.
http://www.datastax.com/documentation/cassandra/2.0/cassandra/security/security_config_native_authenticate_t.htm

http://golang.org/pkg/net/url/#Userinfo

