### PR TITLE
Support go-bindata assets

### DIFF
--- a/file/file.go
+++ b/file/file.go
@@ -5,14 +5,13 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/mattes/migrate/migrate/direction"
 	"go/token"
-	"io/ioutil"
-	"path"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/mattes/migrate/migrate/direction"
 )
 
 var filenameRegex = `^([0-9]+)_(.*)\.(up|down)\.%s$`
@@ -43,6 +42,10 @@ type File struct {
 
 	// UP or DOWN migration
 	Direction direction.Direction
+
+	// the store used to read the file contents;
+	// defaults to FSStore (a regular file system)
+	Store FileStore
 }
 
 // Files is a slice of Files
@@ -66,7 +69,11 @@ type MigrationFiles []MigrationFile
 // ReadContent reads the file's content if the content is empty
 func (f *File) ReadContent() error {
 	if len(f.Content) == 0 {
-		content, err := ioutil.ReadFile(path.Join(f.Path, f.FileName))
+		store := f.Store
+		if store == nil {
+			store = &FSStore{}
+		}
+		content, err := store.ReadFile(f)
 		if err != nil {
 			return err
 		}
@@ -149,10 +156,10 @@ func (mf *MigrationFiles) From(version uint64, relativeN int) (Files, error) {
 	return files, nil
 }
 
-// ReadMigrationFiles reads all migration files from a given path
-func ReadMigrationFiles(path string, filenameRegex *regexp.Regexp) (files MigrationFiles, err error) {
+// ReadMigrationFilesFromStore reads all migration files from a given file store
+func ReadMigrationFilesFromStore(store FileStore, path string, filenameRegex *regexp.Regexp) (files MigrationFiles, err error) {
 	// find all migration files in path
-	ioFiles, err := ioutil.ReadDir(path)
+	dirFiles, err := store.ReadDir(path)
 	if err != nil {
 		return nil, err
 	}
@@ -163,10 +170,10 @@ func ReadMigrationFiles(path string, filenameRegex *regexp.Regexp) (files Migrat
 		d        direction.Direction
 	}
 	tmpFiles := make([]*tmpFile, 0)
-	for _, file := range ioFiles {
-		version, name, d, err := parseFilenameSchema(file.Name(), filenameRegex)
+	for _, file := range dirFiles {
+		version, name, d, err := parseFilenameSchema(file, filenameRegex)
 		if err == nil {
-			tmpFiles = append(tmpFiles, &tmpFile{version, name, file.Name(), d})
+			tmpFiles = append(tmpFiles, &tmpFile{version, name, file, d})
 		}
 	}
 
@@ -189,6 +196,7 @@ func ReadMigrationFiles(path string, filenameRegex *regexp.Regexp) (files Migrat
 					Name:      file.name,
 					Content:   nil,
 					Direction: direction.Up,
+					Store:     store,
 				}
 				lookFordirection = direction.Down
 			case direction.Down:
@@ -199,6 +207,7 @@ func ReadMigrationFiles(path string, filenameRegex *regexp.Regexp) (files Migrat
 					Name:      file.name,
 					Content:   nil,
 					Direction: direction.Down,
+					Store:     store,
 				}
 				lookFordirection = direction.Up
 			default:
@@ -216,6 +225,7 @@ func ReadMigrationFiles(path string, filenameRegex *regexp.Regexp) (files Migrat
 							Name:      file2.name,
 							Content:   nil,
 							Direction: direction.Up,
+							Store:     store,
 						}
 					case direction.Down:
 						migrationFile.DownFile = &File{
@@ -225,6 +235,7 @@ func ReadMigrationFiles(path string, filenameRegex *regexp.Regexp) (files Migrat
 							Name:      file2.name,
 							Content:   nil,
 							Direction: direction.Down,
+							Store:     store,
 						}
 					}
 					break
@@ -238,6 +249,11 @@ func ReadMigrationFiles(path string, filenameRegex *regexp.Regexp) (files Migrat
 
 	sort.Sort(newFiles)
 	return newFiles, nil
+}
+
+// ReadMigrationFiles reads all migration files from a given path
+func ReadMigrationFiles(path string, filenameRegex *regexp.Regexp) (files MigrationFiles, err error) {
+	return ReadMigrationFilesFromStore(&FSStore{}, path, filenameRegex)
 }
 
 // parseFilenameSchema parses the filename

--- a/file/filestore.go
+++ b/file/filestore.go
@@ -1,0 +1,54 @@
+package file
+
+import (
+	"io/ioutil"
+	"path"
+)
+
+// FileStore interface is an abstraction layer with minimal functionality
+// to get a list of migration files and read their contents.
+type FileStore interface {
+	// Read contents of a given file
+	ReadFile(*File) ([]byte, error)
+	// List filenames of a given directory (including subdirectories)
+	ReadDir(string) ([]string, error)
+}
+
+// FSStore is a regular file system store
+type FSStore struct{}
+
+// Read contents of a file
+func (s FSStore) ReadFile(f *File) ([]byte, error) {
+	return ioutil.ReadFile(path.Join(f.Path, f.FileName))
+}
+
+// List file in a given dir
+func (s FSStore) ReadDir(dirname string) ([]string, error) {
+	if fs, err := ioutil.ReadDir(dirname); err != nil {
+		return nil, err
+	} else {
+		res := make([]string, len(fs))
+		for i := range fs {
+			res[i] = fs[i].Name()
+		}
+		return res, nil
+	}
+}
+
+// AssetStore is a bindatata asset store
+type AssetStore struct {
+	// Asset should return content of file in path if exists
+	Asset func(path string) ([]byte, error)
+	// AssetDir should return list of files in the path
+	AssetDir func(path string) ([]string, error)
+}
+
+// Read contents of a file
+func (s AssetStore) ReadFile(f *File) ([]byte, error) {
+	return s.Asset(path.Join(f.Path, f.FileName))
+}
+
+// List file in a given dir
+func (s AssetStore) ReadDir(dirname string) ([]string, error) {
+	return s.AssetDir(dirname)
+}

--- a/file/filestore_test.go
+++ b/file/filestore_test.go
@@ -1,0 +1,157 @@
+package file
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestFSStore(t *testing.T) {
+	RegisterTestingT(t)
+
+	var files []string
+	var bs []byte
+
+	tmpdir, err := ioutil.TempDir("/tmp", "TestLookForMigrationFilesInSearchPath")
+	Ω(err).ShouldNot(HaveOccurred())
+	defer os.RemoveAll(tmpdir)
+
+	err = ioutil.WriteFile(path.Join(tmpdir, "a"), []byte("a"), 0755)
+	Ω(err).ShouldNot(HaveOccurred())
+
+	err = os.Mkdir(path.Join(tmpdir, "x"), 0755)
+	Ω(err).ShouldNot(HaveOccurred())
+	err = ioutil.WriteFile(path.Join(tmpdir, "x/b"), []byte("b"), 0755)
+	Ω(err).ShouldNot(HaveOccurred())
+	err = ioutil.WriteFile(path.Join(tmpdir, "x/c"), nil, 0755)
+	Ω(err).ShouldNot(HaveOccurred())
+
+	err = os.Mkdir(path.Join(tmpdir, "y"), 0755)
+	Ω(err).ShouldNot(HaveOccurred())
+
+	files, err = FSStore{}.ReadDir(tmpdir)
+	Ω(err).ShouldNot(HaveOccurred())
+	Ω(files).Should(ConsistOf("a", "x", "y"))
+
+	files, err = FSStore{}.ReadDir(path.Join(tmpdir, "x"))
+	Ω(err).ShouldNot(HaveOccurred())
+	Ω(files).Should(ConsistOf("b", "c"))
+
+	files, err = FSStore{}.ReadDir(path.Join(tmpdir, "y"))
+	Ω(err).ShouldNot(HaveOccurred())
+	Ω(files).Should(BeEmpty())
+
+	files, err = FSStore{}.ReadDir(path.Join(tmpdir, "XXX"))
+	Ω(err).Should(HaveOccurred())
+	Ω(files).Should(BeNil())
+
+	bs, err = FSStore{}.ReadFile(&File{
+		Path:     tmpdir,
+		FileName: "a",
+	})
+	Ω(err).ShouldNot(HaveOccurred())
+	Ω(bs).Should(Equal([]byte("a")))
+
+	bs, err = FSStore{}.ReadFile(&File{
+		Path:     path.Join(tmpdir, "x"),
+		FileName: "b",
+	})
+	Ω(err).ShouldNot(HaveOccurred())
+	Ω(bs).Should(Equal([]byte("b")))
+
+	bs, err = FSStore{}.ReadFile(&File{
+		Path:     path.Join(tmpdir, "x"),
+		FileName: "AAA",
+	})
+	Ω(err).Should(HaveOccurred())
+	Ω(bs).Should(BeNil())
+
+	bs, err = FSStore{}.ReadFile(&File{
+		Path:     path.Join(tmpdir, "ZZZ"),
+		FileName: "b",
+	})
+	Ω(err).Should(HaveOccurred())
+	Ω(bs).Should(BeNil())
+}
+
+func TestAssetStore(t *testing.T) {
+	RegisterTestingT(t)
+
+	var files []string
+	var bs []byte
+	var err error
+
+	store := AssetStore{
+		Asset: func(path string) ([]byte, error) {
+			switch path {
+			case "a":
+				return []byte("a"), nil
+			case "x/b":
+				return []byte("b"), nil
+			case "x/c":
+				return []byte{}, nil
+			default:
+				return nil, fmt.Errorf("unknown file: %s", path)
+			}
+		},
+		AssetDir: func(path string) ([]string, error) {
+			switch path {
+			case "":
+				return []string{"a", "x", "y"}, nil
+			case "x":
+				return []string{"b", "c"}, nil
+			case "y":
+				return []string{}, nil
+			default:
+				return nil, fmt.Errorf("unknown dir: %s", path)
+			}
+		},
+	}
+
+	files, err = store.ReadDir("")
+	Ω(err).ShouldNot(HaveOccurred())
+	Ω(files).Should(ConsistOf("a", "x", "y"))
+
+	files, err = store.ReadDir("x")
+	Ω(err).ShouldNot(HaveOccurred())
+	Ω(files).Should(ConsistOf("b", "c"))
+
+	files, err = store.ReadDir("y")
+	Ω(err).ShouldNot(HaveOccurred())
+	Ω(files).Should(BeEmpty())
+
+	files, err = store.ReadDir("XXX")
+	Ω(err).Should(HaveOccurred())
+	Ω(files).Should(BeNil())
+
+	bs, err = store.ReadFile(&File{
+		FileName: "a",
+	})
+	Ω(err).ShouldNot(HaveOccurred())
+	Ω(bs).Should(Equal([]byte("a")))
+
+	bs, err = store.ReadFile(&File{
+		Path:     "x",
+		FileName: "b",
+	})
+	Ω(err).ShouldNot(HaveOccurred())
+	Ω(bs).Should(Equal([]byte("b")))
+
+	bs, err = store.ReadFile(&File{
+		Path:     "x",
+		FileName: "AAA",
+	})
+	Ω(err).Should(HaveOccurred())
+	Ω(bs).Should(BeNil())
+
+	bs, err = store.ReadFile(&File{
+		Path:     "ZZZ",
+		FileName: "b",
+	})
+	Ω(err).Should(HaveOccurred())
+	Ω(bs).Should(BeNil())
+}

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -212,7 +212,8 @@ func Create(url, migrationsPath, name string) (*file.MigrationFile, error) {
 	if err != nil {
 		return nil, err
 	}
-	files, err := file.ReadMigrationFiles(migrationsPath, file.FilenameRegex(d.FilenameExtension()))
+	files, err := file.ReadMigrationFilesFromStore(fileStore, migrationsPath,
+		file.FilenameRegex(d.FilenameExtension()))
 	if err != nil {
 		return nil, err
 	}
@@ -268,7 +269,8 @@ func initDriverAndReadMigrationFilesAndGetVersion(url, migrationsPath string) (d
 	if err != nil {
 		return nil, nil, 0, err
 	}
-	files, err := file.ReadMigrationFiles(migrationsPath, file.FilenameRegex(d.FilenameExtension()))
+	files, err := file.ReadMigrationFilesFromStore(fileStore, migrationsPath,
+		file.FilenameRegex(d.FilenameExtension()))
 	if err != nil {
 		d.Close() // TODO what happens with errors from this func?
 		return nil, nil, 0, err
@@ -303,6 +305,23 @@ func Graceful() {
 // stop execution immediately.
 func NonGraceful() {
 	interrupts = false
+}
+
+// File store to read migration scripts from
+var fileStore file.FileStore = &file.FSStore{}
+
+// Read migration scripts from a given file store.
+//
+// In order to use bindata asset as a store:
+// 	import "github.com/mattes/migrate/migrate"
+// 	import "github.com/mattes/migrate/file"
+// 	...
+// 	migrate.UseStore(file.AssetStore{
+// 		Asset: Asset,
+// 		AssetDir: AssetDir,
+// 	})
+func UseStore(store file.FileStore) {
+	fileStore = store
 }
 
 // interrupts returns a signal channel if interrupts checking is


### PR DESCRIPTION
Currently migrate tool reads all migration scripts from the file-system.

The pull request allows to read migration scripts embedded into the application with [go-bindata](https://github.com/jteeuwen/go-bindata).

I've tried to keep the changes as minimal as possible and to avoid API breaking changes.
