### PR TITLE
Add driver for sqlite3

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -10,6 +10,7 @@ import (
 	"github.com/mattes/migrate/driver/cassandra"
 	"github.com/mattes/migrate/driver/mysql"
 	"github.com/mattes/migrate/driver/postgres"
+	"github.com/mattes/migrate/driver/sqlite3"
 	"github.com/mattes/migrate/file"
 )
 
@@ -74,6 +75,13 @@ func New(url string) (Driver, error) {
 	case "cassandra":
 		d := &cassandra.Driver{}
 		verifyFilenameExtension("cassanda", d)
+		if err := d.Initialize(url); err != nil {
+			return nil, err
+		}
+		return d, nil
+	case "sqlite3":
+		d := &sqlite3.Driver{}
+		verifyFilenameExtension("sqlite3", d)
 		if err := d.Initialize(url); err != nil {
 			return nil, err
 		}

--- a/driver/sqlite3/README.md
+++ b/driver/sqlite3/README.md
@@ -1,0 +1,21 @@
+# Sqlite3 Driver
+
+* Runs migrations in transcations.
+  That means that if a migration failes, it will be safely rolled back.
+* Tries to return helpful error messages.
+* Stores migration version details in table ``schema_migrations``.
+  This table will be auto-generated.
+
+
+## Usage
+
+```bash
+migrate -url sqlite3://database.sqlite -path ./db/migrations create add_field_to_table
+migrate -url sqlite3://database.sqlite -path ./db/migrations up
+migrate help # for more info
+```
+
+## Authors
+
+* Matthias Kadenbach, https://github.com/mattes
+* Caesar Wirth, https://github.com/cjwirth

--- a/driver/sqlite3/sqlite3.go
+++ b/driver/sqlite3/sqlite3.go
@@ -1,0 +1,125 @@
+// Package sqlite3 implements the Driver interface.
+package sqlite3
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"github.com/mattes/migrate/file"
+	"github.com/mattes/migrate/migrate/direction"
+	"github.com/mattn/go-sqlite3"
+	"strings"
+)
+
+type Driver struct {
+	db *sql.DB
+}
+
+const tableName = "schema_migration"
+
+func (driver *Driver) Initialize(url string) error {
+	filename := strings.SplitN(url, "sqlite3://", 2)
+	if len(filename) != 2 {
+		return errors.New("invalid sqlite3:// scheme")
+	}
+
+	db, err := sql.Open("sqlite3", filename[1])
+	if err != nil {
+		return err
+	}
+	if err := db.Ping(); err != nil {
+		return err
+	}
+	driver.db = db
+
+	if err := driver.ensureVersionTableExists(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (driver *Driver) Close() error {
+	if err := driver.db.Close(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (driver *Driver) ensureVersionTableExists() error {
+	if _, err := driver.db.Exec("CREATE TABLE IF NOT EXISTS " + tableName + " (version INTEGER PRIMARY KEY AUTOINCREMENT);"); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (driver *Driver) FilenameExtension() string {
+	return "sql"
+}
+
+func (driver *Driver) Migrate(f file.File, pipe chan interface{}) {
+	defer close(pipe)
+	pipe <- f
+
+	tx, err := driver.db.Begin()
+	if err != nil {
+		pipe <- err
+		return
+	}
+
+	if f.Direction == direction.Up {
+		if _, err := tx.Exec("INSERT INTO "+tableName+" (version) VALUES (?)", f.Version); err != nil {
+			pipe <- err
+			if err := tx.Rollback(); err != nil {
+				pipe <- err
+			}
+			return
+		}
+	} else if f.Direction == direction.Down {
+		if _, err := tx.Exec("DELETE FROM "+tableName+" WHERE version=?", f.Version); err != nil {
+			pipe <- err
+			if err := tx.Rollback(); err != nil {
+				pipe <- err
+			}
+			return
+		}
+	}
+
+	if err := f.ReadContent(); err != nil {
+		pipe <- err
+		return
+	}
+
+	if _, err := tx.Exec(string(f.Content)); err != nil {
+		sqliteErr, isErr := err.(sqlite3.Error)
+
+		if isErr {
+			// The sqlite3 library only provides error codes, not position information. Output what we do know
+			pipe <- errors.New(fmt.Sprintf("SQLite Error (%s); Extended (%s)\nError: %s", sqliteErr.Code.Error(), sqliteErr.ExtendedCode.Error(), sqliteErr.Error()))
+		} else {
+			pipe <- errors.New(fmt.Sprintf("An error occurred: %s", err.Error()))
+		}
+
+		if err := tx.Rollback(); err != nil {
+			pipe <- err
+		}
+		return
+	}
+
+	if err := tx.Commit(); err != nil {
+		pipe <- err
+		return
+	}
+}
+
+func (driver *Driver) Version() (uint64, error) {
+	var version uint64
+	err := driver.db.QueryRow("SELECT version FROM " + tableName + " ORDER BY version DESC LIMIT 1").Scan(&version)
+	switch {
+	case err == sql.ErrNoRows:
+		return 0, nil
+	case err != nil:
+		return 0, err
+	default:
+		return version, nil
+	}
+}

--- a/driver/sqlite3/sqlite3_test.go
+++ b/driver/sqlite3/sqlite3_test.go
@@ -1,0 +1,94 @@
+package sqlite3
+
+import (
+	"database/sql"
+	"github.com/mattes/migrate/file"
+	"github.com/mattes/migrate/migrate/direction"
+	pipep "github.com/mattes/migrate/pipe"
+	"testing"
+)
+
+// TestMigrate runs some additional tests on Migrate()
+// Basic testing is already done in migrate/migrate_test.go
+func TestMigrate(t *testing.T) {
+	driverFile := ":memory:"
+	driverUrl := "sqlite3://" + driverFile
+
+	// prepare clean database
+	connection, err := sql.Open("sqlite3", driverFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := connection.Exec(`
+							DROP TABLE IF EXISTS yolo;
+							DROP TABLE IF EXISTS ` + tableName + `;`); err != nil {
+		t.Fatal(err)
+	}
+
+	d := &Driver{}
+	if err := d.Initialize(driverUrl); err != nil {
+		t.Fatal(err)
+	}
+
+	files := []file.File{
+		{
+			Path:      "/foobar",
+			FileName:  "001_foobar.up.sql",
+			Version:   1,
+			Name:      "foobar",
+			Direction: direction.Up,
+			Content: []byte(`
+				CREATE TABLE yolo (
+					id INTEGER PRIMARY KEY AUTOINCREMENT
+				);
+			`),
+		},
+		{
+			Path:      "/foobar",
+			FileName:  "002_foobar.down.sql",
+			Version:   1,
+			Name:      "foobar",
+			Direction: direction.Down,
+			Content: []byte(`
+				DROP TABLE yolo;
+			`),
+		},
+		{
+			Path:      "/foobar",
+			FileName:  "002_foobar.up.sql",
+			Version:   1,
+			Name:      "foobar",
+			Direction: direction.Down,
+			Content: []byte(`
+				CREATE TABLE error (
+					THIS; WILL CAUSE; AN ERROR;
+				)
+			`),
+		},
+	}
+
+	pipe := pipep.New()
+	go d.Migrate(files[0], pipe)
+	errs := pipep.ReadErrors(pipe)
+	if len(errs) > 0 {
+		t.Fatal(errs)
+	}
+
+	pipe = pipep.New()
+	go d.Migrate(files[1], pipe)
+	errs = pipep.ReadErrors(pipe)
+	if len(errs) > 0 {
+		t.Fatal(errs)
+	}
+
+	pipe = pipep.New()
+	go d.Migrate(files[2], pipe)
+	errs = pipep.ReadErrors(pipe)
+	if len(errs) == 0 {
+		t.Error("Expected test case to fail")
+	}
+
+	if err := d.Close(); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Addresses #2 [SQLite Driver](https://github.com/mattes/migrate/issues/2)

To be honest, this is pretty much a copy of the postgres driver. [mattn/go-sqlite3](https://github.com/mattn/go-sqlite3) supports multiple statements in the Exec function, so I copied postgres instead of MySQL.

Things to notice:
- Error messages could be improved. The library (sqlite, not go-sqlite3) does not tell you _where_ the error occurred, just that it did. 
- Third test in `sqlite3_test.go` --> The failure test from postgres/mysql actually does not cause an error in sqlite3 haha

I've used it a little bit for a toy project I'm working on, and it works, but I will admit it hasn't been really stress-tested. 