### PR TITLE
Don't load in all drivers by default #40

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ See GoDoc here: http://godoc.org/github.com/mattes/migrate/migrate
 ```go
 import "github.com/mattes/migrate/migrate"
 
+// Import any required drivers so that they are registered and available
+import _ "github.com/mattes/migrate/drivers/mysql"
+
 // use synchronous versions of migration functions ...
 allErrors, ok := migrate.UpSync("driver://url", "./path")
 if !ok {

--- a/driver/bash/bash.go
+++ b/driver/bash/bash.go
@@ -2,6 +2,7 @@
 package bash
 
 import (
+	"github.com/mattes/migrate/driver/registry"
 	"github.com/mattes/migrate/file"
 	_ "github.com/mattes/migrate/migrate/direction"
 )
@@ -29,4 +30,8 @@ func (driver *Driver) Migrate(f file.File, pipe chan interface{}) {
 
 func (driver *Driver) Version() (uint64, error) {
 	return uint64(0), nil
+}
+
+func init() {
+	registry.RegisterDriver("bash", Driver{})
 }

--- a/driver/cassandra/cassandra.go
+++ b/driver/cassandra/cassandra.go
@@ -4,6 +4,7 @@ package cassandra
 import (
 	"fmt"
 	"github.com/gocql/gocql"
+	"github.com/mattes/migrate/driver/registry"
 	"github.com/mattes/migrate/file"
 	"github.com/mattes/migrate/migrate/direction"
 	"net/url"
@@ -152,4 +153,8 @@ func (driver *Driver) Version() (uint64, error) {
 	var version int64
 	err := driver.session.Query("SELECT version FROM "+tableName+" WHERE versionRow = ?", versionRow).Scan(&version)
 	return uint64(version) - 1, err
+}
+
+func init() {
+	registry.RegisterDriver("cassandra", Driver{})
 }

--- a/driver/mysql/mysql.go
+++ b/driver/mysql/mysql.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/go-sql-driver/mysql"
+	"github.com/mattes/migrate/driver/registry"
 	"github.com/mattes/migrate/file"
 	"github.com/mattes/migrate/migrate/direction"
 	"regexp"
@@ -176,4 +177,8 @@ func (driver *Driver) Version() (uint64, error) {
 	default:
 		return version, nil
 	}
+}
+
+func init() {
+	registry.RegisterDriver("mysql", Driver{})
 }

--- a/driver/postgres/postgres.go
+++ b/driver/postgres/postgres.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/lib/pq"
+	"github.com/mattes/migrate/driver/registry"
 	"github.com/mattes/migrate/file"
 	"github.com/mattes/migrate/migrate/direction"
 	"strconv"
@@ -118,4 +119,8 @@ func (driver *Driver) Version() (uint64, error) {
 	default:
 		return version, nil
 	}
+}
+
+func init() {
+	registry.RegisterDriver("postgres", Driver{})
 }

--- a/driver/registry/registry.go
+++ b/driver/registry/registry.go
@@ -1,0 +1,20 @@
+// Package registry maintains a map of imported and available drivers
+package registry
+
+var driverRegistry map[string]interface{}
+
+// Registers a driver so it can be created from its name. Drivers should
+// call this from an init() function so that they registers themselvse on
+// import
+func RegisterDriver(name string, driver interface{}) {
+	driverRegistry[name] = driver
+}
+
+// Retrieves a registered driver by name
+func GetDriver(name string) interface{} {
+	return driverRegistry[name]
+}
+
+func init() {
+	driverRegistry = make(map[string]interface{})
+}

--- a/driver/sqlite3/sqlite3.go
+++ b/driver/sqlite3/sqlite3.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"github.com/mattes/migrate/driver/registry"
 	"github.com/mattes/migrate/file"
 	"github.com/mattes/migrate/migrate/direction"
 	"github.com/mattn/go-sqlite3"
@@ -122,4 +123,8 @@ func (driver *Driver) Version() (uint64, error) {
 	default:
 		return version, nil
 	}
+}
+
+func init() {
+	registry.RegisterDriver("sqlite3", Driver{})
 }

--- a/migrate/migrate_test.go
+++ b/migrate/migrate_test.go
@@ -3,6 +3,8 @@ package migrate
 import (
 	"io/ioutil"
 	"testing"
+	// Ensure imports for each driver we wish to test
+	_ "github.com/mattes/migrate/driver/postgres"
 )
 
 // Add Driver URLs here to test basic Up, Down, .. functions.


### PR DESCRIPTION
Requires activating drivers with a _ style import, e.g.
`import _ " github.com/mattes/migrate/driver/postgres"`

I guess it's not fully backwards compatible (users will need to add the import for the driver they wish to use) but it avoids all dependencies being pulled in when they aren't needed.

