### PR TITLE
Proposed fix for migration file name clashes

### DIFF
--- a/file/file_test.go
+++ b/file/file_test.go
@@ -209,3 +209,41 @@ func TestFiles(t *testing.T) {
 	}
 
 }
+
+func TestDuplicateFiles(t *testing.T) {
+	dups := []string{
+		"001_migration.up.sql",
+		"001_duplicate.up.sql",
+	}
+
+	root, cleanFn, err := makeFiles("TestDuplicateFiles", dups...)
+	defer cleanFn()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = ReadMigrationFiles(root, FilenameRegex("sql"))
+	if err == nil {
+		t.Fatal("Expected duplicate migration file error")
+	}
+}
+
+func makeFiles(testname string, names ...string) (root string, cleanup func(), err error) {
+	cleanup = func() {}
+	root, err = ioutil.TempDir("/tmp", testname)
+	if err != nil {
+		return
+	}
+	cleanup = func() { os.RemoveAll(root) }
+	if err = ioutil.WriteFile(path.Join(root, "nonsense.txt"), nil, 0755); err != nil {
+		return
+	}
+
+	for _, name := range names {
+		if err = ioutil.WriteFile(path.Join(root, name), nil, 0755); err != nil {
+			return
+		}
+	}
+	return
+}

--- a/file/file_test.go
+++ b/file/file_test.go
@@ -229,6 +229,10 @@ func TestDuplicateFiles(t *testing.T) {
 	}
 }
 
+// makeFiles takes an identifier, and a list of file names and uses them to create a temporary
+// directory populated with files named with the names passed in.  makeFiles returns the root
+// directory name, and a func suitable for a defer cleanup to remove the temporary files after
+// the calling function exits.
 func makeFiles(testname string, names ...string) (root string, cleanup func(), err error) {
 	cleanup = func() {}
 	root, err = ioutil.TempDir("/tmp", testname)


### PR DESCRIPTION
This is a proposed fix for #45 

I added a unit test to demonstrate the issue, and a proposed solution.  Both the test and the fix could be leveraged for more refactoring if that's of interest.