### PR TITLE
Fix travis build file to match reality

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: go
 
 go:
-  - 1.2
   - 1.3
+  - 1.4
+  - 1.5
   - tip
 
 addons:


### PR DESCRIPTION
This project depends on github.com/gocql/gocql, which does not support
go 1.2.

Update the .travis.yml file to match that reality.

Add go 1.4 and 1.5 to the test matrix.