### PR TITLE
Streamline driver code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+test.db

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -7,3 +7,21 @@ func TestNew(t *testing.T) {
 		t.Error("no error although driver unknown")
 	}
 }
+
+func TestNewBash(t *testing.T) {
+	driver, err := New("bash://url")
+	if err != nil {
+		t.Error("error although bash driver known")
+	}
+	version, err := driver.Version()
+	if version != 0 {
+		t.Errorf("expected bash driver version to be 0, got %d\n", version)
+	}
+}
+
+func TestNewSqlite3(t *testing.T) {
+	_, err := New("sqlite3://test.db")
+	if err != nil {
+		t.Error("error although sqlite3 driver known")
+	}
+}

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -1,8 +1,6 @@
 package driver
 
-import (
-	"testing"
-)
+import "testing"
 
 func TestNew(t *testing.T) {
 	if _, err := New("unknown://url"); err == nil {


### PR DESCRIPTION
This branch:

1. Streamlines the repetitive code in the driver switch statement by using a map of schemes to drivers.
2. Adds tests for the presence of drivers (just bash and sqlite3 as the larger systems obviously need a running instance of the particular database) as right now the test just checks for an invalid driver.

All tests passing, hope this helps!