### PR TITLE
Optional transactions

### DIFF
--- a/driver/postgres/postgres.go
+++ b/driver/postgres/postgres.go
@@ -86,7 +86,13 @@ func (driver *Driver) Migrate(f file.File, pipe chan interface{}) {
 		return
 	}
 
-	if _, err := tx.Exec(string(f.Content)); err != nil {
+	if f.UseTransactions == false {
+		_, err = driver.db.Query(string(f.Content))
+	} else {
+		_, err = tx.Exec(string(f.Content))
+	}
+
+	if err != nil {
 		pqErr := err.(*pq.Error)
 		offset, err := strconv.Atoi(pqErr.Position)
 		if err == nil && offset >= 0 {
@@ -100,6 +106,7 @@ func (driver *Driver) Migrate(f file.File, pipe chan interface{}) {
 		if err := tx.Rollback(); err != nil {
 			pipe <- err
 		}
+
 		return
 	}
 

--- a/file/file.go
+++ b/file/file.go
@@ -71,9 +71,10 @@ func (f *File) ReadContent() error {
 	if len(f.Content) == 0 {
 		content, err := ioutil.ReadFile(path.Join(f.Path, f.FileName))
 
-		lines := strings.Split(string(content), "\n")
+		r := bytes.NewBuffer(content)
+		line, err := r.ReadString('\n')
 
-		f.UseTransactions = !strings.Contains(lines[0], "-- @NoTransactions")
+		f.UseTransactions = !strings.Contains(line, "-- @NoTransactions")
 
 		if err != nil {
 			return err

--- a/file/file.go
+++ b/file/file.go
@@ -43,6 +43,9 @@ type File struct {
 
 	// UP or DOWN migration
 	Direction direction.Direction
+
+	// Use transaction
+	UseTransactions bool
 }
 
 // Files is a slice of Files
@@ -67,9 +70,15 @@ type MigrationFiles []MigrationFile
 func (f *File) ReadContent() error {
 	if len(f.Content) == 0 {
 		content, err := ioutil.ReadFile(path.Join(f.Path, f.FileName))
+
+		lines := strings.Split(string(content), "\n")
+
+		f.UseTransactions = !strings.Contains(lines[0], "-- @NoTransactions")
+
 		if err != nil {
 			return err
 		}
+
 		f.Content = content
 	}
 	return nil


### PR DESCRIPTION
This is merely a proof-of-concept to using optional transactions for migrations. In this example it reads the migration being applied and looks for `-- @NoTransactions` on the first line. This will disable transactions.

As you see I have not written any tests or written any implementation for any of the other drivers, but I mostly open this pull request to discuss if this is the correct way to implement this.

Is this a viable way of solving the issue? See issue #13.
