### PR TITLE
https://github.com/mattn/go-sqlite3 is cgo, so CGO_ENABLED must be true

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ go-build:
   <<: *go
   command: sh -c 'go get -v && go build -ldflags ''-s'' -o migrater'
   environment:
-    CGO_ENABLED: 0
+    CGO_ENABLED: 1
 postgres:
   image: postgres
 mysql:


### PR DESCRIPTION
go-build container throws the following:

package github.com/mattn/go-sqlite3: C source files not allowed when not using cgo or SWIG: sqlite3-binding.c