### PR TITLE
gocql doesn't support cassandra > 2.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,4 +23,4 @@ mysql:
     MYSQL_DATABASE: migratetest
     MYSQL_ALLOW_EMPTY_PASSWORD: yes
 cassandra:
-  image: cassandra
+  image: cassandra:2.2


### PR DESCRIPTION
This should fix the failing builds.