### PR TITLE
Add support for Cassandra >= 3 with protocol version 4

### DIFF
--- a/driver/cassandra/cassandra.go
+++ b/driver/cassandra/cassandra.go
@@ -4,6 +4,7 @@ package cassandra
 import (
 	"fmt"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -40,10 +41,10 @@ const (
 )
 
 // Cassandra Driver URL format:
-// cassandra://host:port/keyspace
+// cassandra://host:port/keyspace?protocol=version
 //
 // Example:
-// cassandra://localhost/SpaceOfKeys
+// cassandra://localhost/SpaceOfKeys?protocol=4
 func (driver *Driver) Initialize(rawurl string) error {
 	u, err := url.Parse(rawurl)
 
@@ -51,6 +52,15 @@ func (driver *Driver) Initialize(rawurl string) error {
 	cluster.Keyspace = u.Path[1:len(u.Path)]
 	cluster.Consistency = gocql.All
 	cluster.Timeout = 1 * time.Minute
+
+	if len(u.Query().Get("protocol")) > 0 {
+		protoversion, err := strconv.Atoi(u.Query().Get("protocol"))
+		if err != nil {
+			return err
+		}
+
+		cluster.ProtoVersion = protoversion
+	}
 
 	// Check if url user struct is null
 	if u.User != nil {


### PR DESCRIPTION
I added this as a url query as I'm not sure of the backwards compatibility with previous version of the protocol, but I'm open to ideas

I'm also open to suggestions of testing, since the docker image isn't Cassandra 3, but I have testing with my cluster and it seems to work...