### PR TITLE
Some test tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: required
 go:
   - 1.4
   - 1.5
+  - 1.6
 
 services:
   - docker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,6 @@ mysql:
   image: mysql
   environment:
     MYSQL_DATABASE: migratetest
-    MYSQL_ALLOW_EMPTY_PASSWORD: yes
+    MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
 cassandra:
   image: cassandra:2.2

--- a/migrate/migrate_test.go
+++ b/migrate/migrate_test.go
@@ -59,7 +59,7 @@ func TestCreate(t *testing.T) {
 func TestReset(t *testing.T) {
 	for _, driverUrl := range driverUrls {
 		t.Logf("Test driver: %s", driverUrl)
-		tmpdir, err := ioutil.TempDir("/", "migrate-test")
+		tmpdir, err := ioutil.TempDir("", "migrate-test")
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Changing the syntax of docker-compose.yml to make it compatible with recent releases of docker-compose (it still works on docker-compose 1.4, which is used in Travis).

I also changed a call to ioutil.TempDir in migrate_test to make it more friendly to local based development (non-Docker).

Last, but not least, I added Go 1.6 to travis.yml.
