### PR TITLE
fix travis build in non-mattes forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ go:
   - 1.4
   - 1.5
 
+go_import_path: github.com/mattes/migrate
+
 services:
   - docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,6 @@ services:
   - docker
 
 before_install:
-    - curl -L https://github.com/docker/compose/releases/download/1.4.2/docker-compose-`uname -s`-`uname -m` > docker-compose
-    - chmod +x docker-compose
-    - sudo mv docker-compose /usr/local/bin
     - sed -i -e 's/golang/golang:'"$TRAVIS_GO_VERSION"'/' docker-compose.yml
 
 script: make test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,6 @@ mysql:
   image: mysql
   environment:
     MYSQL_DATABASE: migratetest
-    MYSQL_ALLOW_EMPTY_PASSWORD: yes
+    MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
 cassandra:
   image: cassandra:2.2


### PR DESCRIPTION
The new go_import_path corrects the tests in TravisCI when run in forks (like jmhodges/migrate) that are not mattes/migrate.

Along the way, use the now built-in docker-compose in TravisCI. It's the same version as was being downloaded.
