### PR TITLE
use timestamp (to seconds precision) for versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ go:
   - 1.4
   - 1.5
 
+go_import_path: github.com/mattes/migrate
+
 services:
   - docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,6 @@ services:
   - docker
 
 before_install:
-    - curl -L https://github.com/docker/compose/releases/download/1.4.2/docker-compose-`uname -s`-`uname -m` > docker-compose
-    - chmod +x docker-compose
-    - sudo mv docker-compose /usr/local/bin
     - sed -i -e 's/golang/golang:'"$TRAVIS_GO_VERSION"'/' docker-compose.yml
 
 script: make test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,6 @@ mysql:
   image: mysql
   environment:
     MYSQL_DATABASE: migratetest
-    MYSQL_ALLOW_EMPTY_PASSWORD: yes
+    MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
 cassandra:
   image: cassandra:2.2

--- a/driver/cassandra/cassandra_test.go
+++ b/driver/cassandra/cassandra_test.go
@@ -66,7 +66,7 @@ func TestMigrate(t *testing.T) {
 		},
 		{
 			Path:      "/foobar",
-			FileName:  "002_foobar.down.sql",
+			FileName:  "001_foobar.down.sql",
 			Version:   1,
 			Name:      "foobar",
 			Direction: direction.Down,
@@ -76,8 +76,18 @@ func TestMigrate(t *testing.T) {
 		},
 		{
 			Path:      "/foobar",
-			FileName:  "002_foobar.up.sql",
-			Version:   2,
+			FileName:  "20060102150405_bigint.up.sql",
+			Version:   20060102150405,
+			Name:      "bigint",
+			Direction: direction.Up,
+			Content: []byte(`
+               ALTER TABLE yolo ADD okay text;
+            `),
+		},
+		{
+			Path:      "/foobar",
+			FileName:  "20070000000000_foobar.up.sql",
+			Version:   20000000000000,
 			Name:      "foobar",
 			Direction: direction.Up,
 			Content: []byte(`

--- a/driver/mysql/mysql_test.go
+++ b/driver/mysql/mysql_test.go
@@ -28,6 +28,22 @@ func TestMigrate(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	migrate(t, driverUrl)
+
+	if _, err := connection.Exec(`DROP TABLE IF EXISTS yolo, yolo1, ` + tableName); err != nil {
+		t.Fatal(err)
+	}
+
+	// Make an old-style 32-bit int version column that we'll have to upgrade.
+	_, err = connection.Exec("CREATE TABLE IF NOT EXISTS " + tableName + " (version int not null primary key);")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	migrate(t, driverUrl)
+}
+
+func migrate(t *testing.T, driverUrl string) {
 	d := &Driver{}
 	if err := d.Initialize(driverUrl); err != nil {
 		t.Fatal(err)
@@ -52,7 +68,7 @@ func TestMigrate(t *testing.T) {
 		},
 		{
 			Path:      "/foobar",
-			FileName:  "002_foobar.down.sql",
+			FileName:  "001_foobar.down.sql",
 			Version:   1,
 			Name:      "foobar",
 			Direction: direction.Down,
@@ -62,8 +78,18 @@ func TestMigrate(t *testing.T) {
 		},
 		{
 			Path:      "/foobar",
-			FileName:  "002_foobar.up.sql",
-			Version:   2,
+			FileName:  "20060102150405_bigint.up.sql",
+			Version:   20060102150405,
+			Name:      "bigint",
+			Direction: direction.Up,
+			Content: []byte(`
+               ALTER TABLE yolo ADD okay text;
+            `),
+		},
+		{
+			Path:      "/foobar",
+			FileName:  "20070000000000_foobar.up.sql",
+			Version:   20070000000000,
 			Name:      "foobar",
 			Direction: direction.Up,
 			Content: []byte(`

--- a/driver/postgres/postgres.go
+++ b/driver/postgres/postgres.go
@@ -54,7 +54,7 @@ func (driver *Driver) ensureVersionTableExists() error {
 	if dataType != "integer" {
 		return nil
 	}
-	_, err := driver.db.Exec("ALTER TABLE " + pq.QuoteIdentifier(tableName) + " ALTER COLUMN version TYPE bigint")
+	_, err := driver.db.Exec("ALTER TABLE " + tableName + " ALTER COLUMN version TYPE bigint")
 	return err
 }
 

--- a/driver/sqlite3/sqlite3_test.go
+++ b/driver/sqlite3/sqlite3_test.go
@@ -46,7 +46,7 @@ func TestMigrate(t *testing.T) {
 		},
 		{
 			Path:      "/foobar",
-			FileName:  "002_foobar.down.sql",
+			FileName:  "001_foobar.down.sql",
 			Version:   1,
 			Name:      "foobar",
 			Direction: direction.Down,
@@ -56,8 +56,18 @@ func TestMigrate(t *testing.T) {
 		},
 		{
 			Path:      "/foobar",
-			FileName:  "002_foobar.up.sql",
-			Version:   1,
+			FileName:  "20060102150405_bigint.up.sql",
+			Version:   20060102150405,
+			Name:      "bigint",
+			Direction: direction.Up,
+			Content: []byte(`
+               ALTER TABLE yolo ADD COLUMN okay text;
+            `),
+		},
+		{
+			Path:      "/foobar",
+			FileName:  "20070000000000_foobar.up.sql",
+			Version:   20070000000000,
 			Name:      "foobar",
 			Direction: direction.Down,
 			Content: []byte(`

--- a/file/file.go
+++ b/file/file.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/mattes/migrate/migrate/direction"
 	"go/token"
 	"io/ioutil"
 	"path"
@@ -13,6 +12,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/mattes/migrate/migrate/direction"
 )
 
 var filenameRegex = `^([0-9]+)_(.*)\.(up|down)\.%s$`

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -8,9 +8,9 @@ import (
 	"os"
 	"os/signal"
 	"path"
-	"strconv"
 	"strings"
 
+	"github.com/jmhodges/clock"
 	"github.com/mattes/migrate/driver"
 	"github.com/mattes/migrate/file"
 	"github.com/mattes/migrate/migrate/direction"
@@ -217,17 +217,14 @@ func Create(url, migrationsPath, name string) (*file.MigrationFile, error) {
 		return nil, err
 	}
 
-	version := uint64(0)
-	if len(files) > 0 {
-		lastFile := files[len(files)-1]
-		version = lastFile.Version
-	}
-	version += 1
-	versionStr := strconv.FormatUint(version, 10)
+	t := globalClock.Now()
+	version := uint64(t.Unix())
+	versionStr := t.Format("20060102150405")
 
-	length := 4 // TODO(mattes) check existing files and try to guess length
-	if len(versionStr)%length != 0 {
-		versionStr = strings.Repeat("0", length-len(versionStr)%length) + versionStr
+	for _, f := range files {
+		if f.Version == version {
+			return nil, fmt.Errorf("something is possibly wrong with your or another person's clock: found a duplicate migration version for %d", version)
+		}
 	}
 
 	filenamef := "%s_%s.%s.%s"
@@ -315,3 +312,7 @@ func handleInterrupts() chan os.Signal {
 	}
 	return nil
 }
+
+// Just to be overriden in tests. Setting a global isn't ideal for making it
+// available to tests, but we're constrained by our API.
+var globalClock = clock.New()


### PR DESCRIPTION
Depends on #94. That'll need to be reviewed and merged first.

This is backwards compatible with the current incrementing mechanism and won't cause issues for teams with differing versions of migrate.

Using timestamps instead of an incrementing counter reduces the chances of conflicts and invalid migrations states after merging in another branch of code. Since people tend to work on orthogonal parts of the codebase, having to coordinate over incrementing an integer tends to cause merge issues late in the process of putting their code all together.

Along the way, we have to handle the fact that the original MySQL and PostgreSQL tables for migration versions used 32-bit integers instead of 64-bit integers. We inspect the column types of their migration tables and upgrade them non-destructively to 64-integers at the same time we check that the migration table exists. The other databases seem to already have the correct table types.

We also have to introduce a Clock interface for testing the new code well. A Clock is just a handy way to control for time in tests. Since we're constrained by the public API, the Clock instance is a global we swap out during tests. This is not ideal, but usable.
