### PR TITLE
MySQL expects integer, not string

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,6 @@ mysql:
   image: mysql
   environment:
     MYSQL_DATABASE: migratetest
-    MYSQL_ALLOW_EMPTY_PASSWORD: yes
+    MYSQL_ALLOW_EMPTY_PASSWORD: 1
 cassandra:
   image: cassandra:2.2


### PR DESCRIPTION
While running `make` I got following error:

```
~/go_workspace/src/github.com/mattes/migrate • make                                                                                                         11:46  iwan@iwan-developmen
docker-compose run --rm go-test
ERROR: The Compose file './docker-compose.yml' is invalid because:
mysql.environment.MYSQL_ALLOW_EMPTY_PASSWORD contains true, which is an invalid type, it should be a string, number, or a null
Makefile:11: recipe for target 'test' failed
make: *** [test] Error 1
```

OS: Ubuntu 16.04
Go: 1.6
Docker 1.11.1
docker-compose: 1.7.1
