### PR TITLE
Allow specification of schema in postgres connection url

### DIFF
--- a/driver/postgres/README.md
+++ b/driver/postgres/README.md
@@ -14,8 +14,8 @@ migrate -url postgres://user@host:port/database -path ./db/migrations create add
 migrate -url postgres://user@host:port/database -path ./db/migrations up
 migrate help # for more info
 
-# TODO(mattes): thinking about adding some custom flag to allow migration within schemas:
--url="postgres://user@host:port/database?schema=name" 
+# specify the schema within the database to perform migrations using below query string syntax
+-url="postgres://user@host:port/database?schema=name"
 ```
 
 ## Authors


### PR DESCRIPTION
Needed so we can run migrations in our redshift cluster (as we have many schemas within the same database and want to manage migrations separately)

Uses the older postgres syntax for specifying as redshift is secretly postgres 8ish.