### PR TITLE
Postgres 8.x compatibility

### DIFF
--- a/driver/postgres/postgres.go
+++ b/driver/postgres/postgres.go
@@ -43,8 +43,16 @@ func (driver *Driver) Close() error {
 }
 
 func (driver *Driver) ensureVersionTableExists() error {
-	if _, err := driver.db.Exec("CREATE TABLE IF NOT EXISTS " + tableName + " (version int not null primary key);"); err != nil {
+	row := driver.db.QueryRow("select count(*) from pg_class where relname = '" + tableName + "'")
+	var tableExists int
+	err := row.Scan(&tableExists)
+	if err != nil {
 		return err
+	}
+	if tableExists != 1 {
+		if _, err := driver.db.Exec("CREATE TABLE " + tableName + " (version int not null primary key);"); err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Postgres 8 doesn't support `IF NOT EXISTS`.

If you wanted to use migrate on postgres 8 this would be what it takes. The main reason you would want to do that today is to emulate redshift, which wouldn't work anyway as redshift's create table syntax isn't compatible with postgres 8. or 9.