### PR TITLE
Added consistency parameter to cassandra connection string

### DIFF
--- a/driver/cassandra/cassandra.go
+++ b/driver/cassandra/cassandra.go
@@ -204,5 +204,5 @@ func readConsistency(consistency string) (gocql.Consistency, error) {
 		return gocql.Any, nil
 	}
 
-	return gocql.Consistency(-1), errors.New("Invalid consistency \"" + consistency + "\" specified")
+	return gocql.Consistency(0), errors.New("Invalid consistency \"" + consistency + "\" specified")
 }

--- a/driver/cassandra/cassandra.go
+++ b/driver/cassandra/cassandra.go
@@ -189,7 +189,7 @@ func parseConsistency(consistencyStr string) (consistency gocql.Consistency, err
 			var ok bool
 			err, ok = r.(error)
 			if !ok {
-				err = fmt.Errorf("Failed to parse consistency \"%s\": %v", s, r)
+				err = fmt.Errorf("Failed to parse consistency \"%s\": %v", consistencyStr, r)
 			}
 		}
 	}()


### PR DESCRIPTION
Migrate is great. I love it. That said, my development environment doesn't have a full, multi-node Cassandra setup - I have one single container. This makes the default consistency of the Cassandra driver (`gocql.All`) problematic. So, I added a way to specify consistency in the connection string - the same way protocol may be specified. For example,

```
cassandra://localhost/SpaceOfKeys?protocol=4
cassandra://localhost/SpaceOfKeys?protocol=4&consistency=all
cassandra://localhost/SpaceOfKeys?consistency=quorum
```

This PR is a continuation of #112 (moved branches).
