### PR TITLE
Skip tests requiring a DB connection with the '-short' flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,22 @@
+TESTFLAGS?=
 IMAGE=mattes/migrate
 DCR=docker-compose run --rm
-.PHONY: clean test build release docker-build docker-push run
+GOTEST=go test $(TESTFLAGS) `go list  ./... | grep -v "/vendor/"`
 
+.PHONY: clean test build release docker-build docker-push run
 all: release
 
 clean:
 	rm -f migrate
 
-test:
-	$(DCR) go-test
+fmt:
+	@gofmt -s -w `go list -f {{.Dir}} ./... | grep -v "/vendor/"`
+
+test: fmt
+	$(DCR) $(GOTEST)
+
+go-test: fmt
+	@$(GOTEST)
 
 build:
 	$(DCR) go-build

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ fmt:
 	@gofmt -s -w `go list -f {{.Dir}} ./... | grep -v "/vendor/"`
 
 test: fmt
-	$(DCR) $(GOTEST)
+	$(DCR) go-test
 
 go-test: fmt
 	@$(GOTEST)

--- a/driver/cassandra/cassandra_test.go
+++ b/driver/cassandra/cassandra_test.go
@@ -13,6 +13,10 @@ import (
 )
 
 func TestMigrate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
 	var session *gocql.Session
 
 	host := os.Getenv("CASSANDRA_PORT_9042_TCP_ADDR")

--- a/driver/mysql/mysql_test.go
+++ b/driver/mysql/mysql_test.go
@@ -14,6 +14,9 @@ import (
 // TestMigrate runs some additional tests on Migrate().
 // Basic testing is already done in migrate/migrate_test.go
 func TestMigrate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
 	host := os.Getenv("MYSQL_PORT_3306_TCP_ADDR")
 	port := os.Getenv("MYSQL_PORT_3306_TCP_PORT")
 	driverUrl := "mysql://root@tcp(" + host + ":" + port + ")/migratetest"

--- a/driver/postgres/postgres_test.go
+++ b/driver/postgres/postgres_test.go
@@ -13,6 +13,10 @@ import (
 // TestMigrate runs some additional tests on Migrate().
 // Basic testing is already done in migrate/migrate_test.go
 func TestMigrate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
 	host := os.Getenv("POSTGRES_PORT_5432_TCP_ADDR")
 	port := os.Getenv("POSTGRES_PORT_5432_TCP_PORT")
 	driverUrl := "postgres://postgres@" + host + ":" + port + "/template1?sslmode=disable"

--- a/driver/sqlite3/sqlite3_test.go
+++ b/driver/sqlite3/sqlite3_test.go
@@ -12,6 +12,10 @@ import (
 // TestMigrate runs some additional tests on Migrate()
 // Basic testing is already done in migrate/migrate_test.go
 func TestMigrate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
 	driverFile := ":memory:"
 	driverUrl := "sqlite3://" + driverFile
 

--- a/migrate/migrate_test.go
+++ b/migrate/migrate_test.go
@@ -16,6 +16,9 @@ var driverUrls = []string{
 }
 
 func TestCreate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
 	for _, driverUrl := range driverUrls {
 		t.Logf("Test driver: %s", driverUrl)
 		tmpdir, err := ioutil.TempDir("/tmp", "migrate-test")
@@ -57,6 +60,9 @@ func TestCreate(t *testing.T) {
 }
 
 func TestReset(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
 	for _, driverUrl := range driverUrls {
 		t.Logf("Test driver: %s", driverUrl)
 		tmpdir, err := ioutil.TempDir("/", "migrate-test")
@@ -82,6 +88,9 @@ func TestReset(t *testing.T) {
 }
 
 func TestDown(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
 	for _, driverUrl := range driverUrls {
 		t.Logf("Test driver: %s", driverUrl)
 		tmpdir, err := ioutil.TempDir("/tmp", "migrate-test")
@@ -119,6 +128,9 @@ func TestDown(t *testing.T) {
 }
 
 func TestUp(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
 	for _, driverUrl := range driverUrls {
 		t.Logf("Test driver: %s", driverUrl)
 		tmpdir, err := ioutil.TempDir("/tmp", "migrate-test")
@@ -156,6 +168,9 @@ func TestUp(t *testing.T) {
 }
 
 func TestRedo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
 	for _, driverUrl := range driverUrls {
 		t.Logf("Test driver: %s", driverUrl)
 		tmpdir, err := ioutil.TempDir("/tmp", "migrate-test")
@@ -193,6 +208,9 @@ func TestRedo(t *testing.T) {
 }
 
 func TestMigrate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
 	for _, driverUrl := range driverUrls {
 		t.Logf("Test driver: %s", driverUrl)
 		tmpdir, err := ioutil.TempDir("/tmp", "migrate-test")


### PR DESCRIPTION
- go-test target for local testing
