### PR TITLE
Add Ql driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ __Features__
  * [Cassandra](https://github.com/mattes/migrate/tree/master/driver/cassandra)
  * [SQLite](https://github.com/mattes/migrate/tree/master/driver/sqlite3)
  * [MySQL](https://github.com/mattes/migrate/tree/master/driver/mysql) ([experimental](https://github.com/mattes/migrate/issues/1#issuecomment-58728186))
+ * [Ql](https://github.com/mattes/migrate/tree/master/driver/ql)
  * Bash (planned)
 
 Need another driver? Just implement the [Driver interface](http://godoc.org/github.com/mattes/migrate/driver#Driver) and open a PR.

--- a/driver/ql/README.md
+++ b/driver/ql/README.md
@@ -1,0 +1,17 @@
+# Ql Driver
+
+* Supports both in-memory and file ql databases, with the URL schemes `ql+file://` and `ql+memory://`
+    * In-memory driver is not of much use, since the database is destroyed once the migration operation finishes, but is included for completeness.
+* Stores migration version details in automatically generated table ``schema_migrations``.
+
+## Usage
+
+```bash
+migrate -url ql+file://./data.db -path ./migrations create add_field_to_table
+migrate -url ql+file://./data.db -path ./db/migrations up
+migrate help # for more info
+```
+
+## Authors
+
+* Sam Willcocks, https://github.com/wlcx

--- a/driver/ql/ql.go
+++ b/driver/ql/ql.go
@@ -1,0 +1,130 @@
+package ql
+
+import (
+	"database/sql"
+
+	"github.com/mattes/migrate/file"
+	"github.com/mattes/migrate/driver"
+	"github.com/mattes/migrate/migrate/direction"
+
+	_ "github.com/cznic/ql/driver"
+	"strings"
+	"fmt"
+)
+
+const tableName = "schema_migration"
+
+type Driver struct {
+	db *sql.DB
+}
+
+func (d *Driver) Initialize(url string) (err error) {
+	d.db, err = sql.Open("ql", strings.TrimPrefix(url, "ql+"))
+	if err != nil {
+		return
+	}
+	if err = d.db.Ping(); err != nil {
+		return
+	}
+	if err = d.ensureVersionTableExists(); err != nil {
+		return
+	}
+	return
+}
+
+func (d *Driver) Close() error {
+	if err := d.db.Close(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (d *Driver) FilenameExtension() string {
+	return "sql"
+}
+
+func (d *Driver) Migrate(f file.File, pipe chan interface{}) {
+	defer close(pipe)
+	pipe <- f
+
+	tx, err := d.db.Begin()
+	if err != nil {
+		pipe <- err
+		return
+	}
+
+	switch f.Direction {
+	case direction.Up:
+		if _, err := tx.Exec("INSERT INTO "+tableName+" (version) VALUES (uint($1))", f.Version); err != nil {
+			pipe <- err
+			if err := tx.Rollback(); err != nil {
+				pipe <- err
+			}
+			return
+		}
+	case direction.Down:
+		if _, err := tx.Exec("DELETE FROM "+tableName+" WHERE version=uint($1)", f.Version); err != nil {
+			pipe <- err
+			if err := tx.Rollback(); err != nil {
+				pipe <- err
+			}
+			return
+		}
+	}
+
+	if err := f.ReadContent(); err != nil {
+		pipe <- err
+		return
+	}
+
+	if _, err := tx.Exec(string(f.Content)); err != nil {
+		pipe <- err
+		if err := tx.Rollback(); err != nil {
+			pipe <- err
+		}
+		return
+	}
+
+	if err := tx.Commit(); err != nil {
+		pipe <- err
+		return
+	}
+}
+
+func (d *Driver) Version() (uint64, error) {
+	var version uint64
+	err := d.db.QueryRow("SELECT version FROM " + tableName + " ORDER BY version DESC LIMIT 1").Scan(&version)
+	switch {
+	case err == sql.ErrNoRows:
+		return 0, nil
+	case err != nil:
+		return 0, err
+	default:
+		return version, nil
+	}
+}
+
+func (d *Driver) ensureVersionTableExists() error {
+	tx, err := d.db.Begin()
+	if err != nil {
+		return err
+	}
+	if _, err := tx.Exec(fmt.Sprintf(`
+		CREATE TABLE IF NOT EXISTS %s (version uint64);
+		CREATE UNIQUE INDEX IF NOT EXISTS version_unique ON %s (version);
+	`, tableName, tableName)); err != nil {
+		if err := tx.Rollback(); err != nil {
+			return err
+		}
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func init() {
+	driver.RegisterDriver("ql+file", &Driver{})
+	driver.RegisterDriver("ql+memory", &Driver{})
+}

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 	_ "github.com/mattes/migrate/driver/mysql"
 	_ "github.com/mattes/migrate/driver/postgres"
 	_ "github.com/mattes/migrate/driver/sqlite3"
+	_ "github.com/mattes/migrate/driver/ql"
 	"github.com/mattes/migrate/file"
 	"github.com/mattes/migrate/migrate"
 	"github.com/mattes/migrate/migrate/direction"

--- a/migrate/migrate_test.go
+++ b/migrate/migrate_test.go
@@ -10,11 +10,13 @@ import (
 
 	_ "github.com/mattes/migrate/driver/postgres"
 	_ "github.com/mattes/migrate/driver/sqlite3"
+	_ "github.com/mattes/migrate/driver/ql"
 )
 
 // Add Driver URLs here to test basic Up, Down, .. functions.
 var driverUrls = []string{
 	"postgres://postgres@" + os.Getenv("POSTGRES_PORT_5432_TCP_ADDR") + ":" + os.Getenv("POSTGRES_PORT_5432_TCP_PORT") + "/template1?sslmode=disable",
+	"ql+file://./test.db",
 }
 
 func tearDown(driverUrl, tmpdir string) {


### PR DESCRIPTION
Adds a driver for the embedded [Ql database](https://github.com/cznic/ql)

This is a little experimental, but it is working for my own basic usage and the migrate tests pass.

The url schemes had to be a little avant garde, (`ql+file://`, `ql+memory://`)  as else there would be no way of discerning that ql was the desired driver (the ql driver itself accepts just `file:///` and `memory://`).