### PR TITLE
Avoid DDL when checking for versions table #134

### DIFF
--- a/driver/postgres/postgres.go
+++ b/driver/postgres/postgres.go
@@ -43,6 +43,14 @@ func (driver *Driver) Close() error {
 }
 
 func (driver *Driver) ensureVersionTableExists() error {
+	r := driver.db.QueryRow("SELECT count(*) FROM information_schema.tables WHERE table_name = $1;", tableName)
+	c := 0
+	if err := r.Scan(&c); err != nil {
+		return err
+	}
+	if c > 0 {
+		return nil
+	}
 	if _, err := driver.db.Exec("CREATE TABLE IF NOT EXISTS " + tableName + " (version int not null primary key);"); err != nil {
 		return err
 	}

--- a/driver/postgres/postgres_test.go
+++ b/driver/postgres/postgres_test.go
@@ -37,6 +37,11 @@ func TestMigrate(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// testing idempotency: second call should be a no-op, since table already exists
+	if err := d.Initialize(driverUrl); err != nil {
+		t.Fatal(err)
+	}
+
 	files := []file.File{
 		{
 			Path:      "/foobar",


### PR DESCRIPTION
Uses a non-DDL select against information_schema to check for existence of version table.  If version table does exist, and if there are no schema migrations pending, no DDL statements are executed.