### PR TITLE
Change colors for up and down migration arrows

### DIFF
--- a/main.go
+++ b/main.go
@@ -187,10 +187,11 @@ func writePipe(pipe chan interface{}) (ok bool) {
 
 					case file.File:
 						f := item.(file.File)
-						c := color.New(color.FgBlue)
 						if f.Direction == direction.Up {
+							c := color.New(color.FgGreen)
 							c.Print(">")
 						} else if f.Direction == direction.Down {
+							c := color.New(color.FgRed)
 							c.Print("<")
 						}
 						fmt.Printf(" %s\n", f.FileName)


### PR DESCRIPTION
Hopefully you don't mind a minor UI change, but I found it easier to read the migrate output when the up/down arrows (i.e. the `<` or `>`) in the output were different colors. So I changed them from both being blue to "up" being green and "down" being red.

Open to other suggestions if you like the idea but not the colors!