### PR TITLE
Refactor CLI

### DIFF
--- a/main.go
+++ b/main.go
@@ -157,17 +157,8 @@ func DatabaseVersion() {
 	log.Println(version)
 }
 
-func main() {
-	Configure()
-
-	if ShowVersion {
-		log.Printf("Version %s", Version)
-		os.Exit(0)
-	}
-
-	start := time.Now()
-	pipe := pipep.New()
-
+// Dispatch based on the command given in the arguments.
+func Dispatch(pipe chan interface{}) {
 	switch Command {
 	case CommandCreate:
 		Create()
@@ -192,6 +183,20 @@ func main() {
 	default:
 		Usage(1)
 	}
+}
+
+func main() {
+	Configure()
+
+	if ShowVersion {
+		log.Printf("Version %s", Version)
+		os.Exit(0)
+	}
+
+	start := time.Now()
+	pipe := pipep.New()
+
+	Dispatch(pipe)
 
 	if ok := writePipe(pipe); ok {
 		log.Printf("Total time: %s", time.Since(start))

--- a/main.go
+++ b/main.go
@@ -239,7 +239,7 @@ func main() {
 	Configure()
 
 	if ShowVersion {
-		log.Println(Version)
+		log.Printf("Version %s", Version)
 		os.Exit(0)
 	}
 

--- a/main.go
+++ b/main.go
@@ -37,7 +37,7 @@ const (
 	CommandHelp    = "help"
 )
 
-// Flag to indicate that Usage() should not exit
+// NoExit is a flag to indicate that Usage() should not exit
 const NoExit = -1
 
 // Configuration variables
@@ -58,24 +58,16 @@ var (
 	Args []string
 )
 
-// init overrides the default configuration values with values from the environment.
-func init() {
-	DatabaseURL = os.Getenv("MIGRATE_URL")
-}
-
-// Configure strips the first command-line argument (the command name) and passes the remainder to ConfigureArgs().
+// Configure the CLI from the command-line arguments.  If the arguments could not be parsed, the program exits with an error.
 func Configure() {
-	ConfigureArgs(os.Args[1:])
-}
+	DatabaseURL = os.Getenv("MIGRATE_URL")
 
-// ConfigureArgs sets the configuration variables from the command-line arguments.  If the arguments could not be parsed, the program exits with an error.
-func ConfigureArgs(args []string) {
 	flags := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	flags.Usage = func() { Usage(NoExit) }
 	flags.StringVar(&DatabaseURL, "url", DatabaseURL, "")
 	flags.StringVar(&MigrationsPath, "path", MigrationsPath, "")
 	flags.BoolVar(&ShowVersion, "version", ShowVersion, "Show migrate version")
-	flags.Parse(args)
+	flags.Parse(os.Args[1:])
 
 	if MigrationsPath == "" {
 		MigrationsPath, _ = os.Getwd()
@@ -111,16 +103,8 @@ Commands:
 	}
 }
 
-func verifyMigrationsPath() {
-	if MigrationsPath == "" {
-		log.Fatal("Migrations path not given.")
-	}
-}
-
 // Create a new migration in the migration path.
 func Create() {
-	verifyMigrationsPath()
-
 	name := Args[0]
 	if name == "" {
 		log.Fatal("Migration name not given.")
@@ -138,8 +122,6 @@ func Create() {
 
 // Migrate runs all pending migrations in the migration path.
 func Migrate(pipe chan interface{}) {
-	verifyMigrationsPath()
-
 	relative, err := strconv.Atoi(Args[0])
 	if err != nil {
 		log.Fatalf("%q is not a valid number of migrations.", Args[0])
@@ -150,8 +132,6 @@ func Migrate(pipe chan interface{}) {
 
 // Goto migrates the database to a specific version.
 func Goto(pipe chan interface{}) {
-	verifyMigrationsPath()
-
 	target, err := strconv.Atoi(Args[0])
 	if err != nil || target < 0 {
 		log.Fatalf("%q is not a valid target version.", Args[0])
@@ -167,34 +147,8 @@ func Goto(pipe chan interface{}) {
 	go migrate.Migrate(pipe, DatabaseURL, MigrationsPath, relative)
 }
 
-// Up runs all up migrations.
-func Up(pipe chan interface{}) {
-	verifyMigrationsPath()
-	go migrate.Up(pipe, DatabaseURL, MigrationsPath)
-}
-
-// Down runs all down migrations.
-func Down(pipe chan interface{}) {
-	verifyMigrationsPath()
-	go migrate.Down(pipe, DatabaseURL, MigrationsPath)
-}
-
-// Redo rolls back the most recent migration and then applies it again.
-func Redo(pipe chan interface{}) {
-	verifyMigrationsPath()
-	go migrate.Redo(pipe, DatabaseURL, MigrationsPath)
-}
-
-// Reset runs all down migrations followed by all up migrations.
-func Reset(pipe chan interface{}) {
-	verifyMigrationsPath()
-	go migrate.Reset(pipe, DatabaseURL, MigrationsPath)
-}
-
 // DatabaseVersion shows the current migration version.
 func DatabaseVersion() {
-	verifyMigrationsPath()
-
 	version, err := migrate.Version(DatabaseURL, MigrationsPath)
 	if err != nil {
 		log.Fatal(err)
@@ -223,13 +177,13 @@ func main() {
 	case CommandGoto:
 		Goto(pipe)
 	case CommandUp:
-		Up(pipe)
+		go migrate.Up(pipe, DatabaseURL, MigrationsPath)
 	case CommandDown:
-		Down(pipe)
+		go migrate.Down(pipe, DatabaseURL, MigrationsPath)
 	case CommandRedo:
-		Redo(pipe)
+		go migrate.Redo(pipe, DatabaseURL, MigrationsPath)
 	case CommandReset:
-		Reset(pipe)
+		go migrate.Reset(pipe, DatabaseURL, MigrationsPath)
 	case CommandVersion:
 		DatabaseVersion()
 		close(pipe)


### PR DESCRIPTION
This revamps the CLI implementation to be cleaner and more idiomatic.

# Configuration

The configuration now uses package variables.  These are a little easier to read IMO and are better documented.  It also eliminates passing derefed pointers as arguments to functions.

Flag parsing has been moved to a separate top-level function which puts flag parsing and (almost) all error checking in one location.

The command name and the additional args are now parsed immediately after the flags and put in package variables as well so that the rest of the code can use them easily.

# Commands

The command names have been extracted out into constants and the implementation of each command has been moved into a standalone function.  The makes the command loop more obvious and easy to follow.  It also makes the implementation of each command more clear.

Additionally, some of the local variable names have been cleaned up and unnecessary intermediate variables removed. 

# Output

The usage of `fmt` has been eliminated and replaced with `log`.  Since `log` prints a timestamp with each message, the need for the hand-rolled timer has been eliminated.  This does lose the "Overall" time being printed out at the end, but it allows users to see how long each migration took or how long it ran before erroring out.  The overall time can be eyeballed from looking at the first and last timestamp so it's not truly lost, just not explicitly stated.

The several instances of 

```go
fmt.Print(msg)
os.Exit(1)
```

have been replaced with a more idiomatic `log.Fatal(msg)`

It is important to note that the change from `fmt` to `log` does change the output from going to STDOUT to STDERR.  If this is likely to break clients, it is possible to add a call to `log.SetOutput(os.Stdout)` in an `init` function to mitigate the effect.

Also, several instances of unnecessary intermediate variables (mostly around color output) were removed and several redundant casts in `writePipe` were eliminated.