### PR TITLE
Postgres: version table existence check in current schema

### DIFF
--- a/driver/postgres/postgres.go
+++ b/driver/postgres/postgres.go
@@ -43,7 +43,7 @@ func (driver *Driver) Close() error {
 }
 
 func (driver *Driver) ensureVersionTableExists() error {
-	r := driver.db.QueryRow("SELECT count(*) FROM information_schema.tables WHERE table_name = $1;", tableName)
+	r := driver.db.QueryRow("SELECT count(*) FROM information_schema.tables WHERE table_name = $1 AND table_schema = (SELECT current_schema());", tableName)
 	c := 0
 	if err := r.Scan(&c); err != nil {
 		return err


### PR DESCRIPTION
When running migrations in parallel on the same database but in different schemas, `ensureVersionTableExists` was schema-agnostic. This meant that having one `schema_migrations`, no matter in which schema, -could even be outside the search_path- would prevent the creation of more `schema_migrations` tables in different schemas.

I'm not sure whether the check should only look at the current schema or the whole search_path. For our use-case (testing packages in parallel using separate schemas) the former was sufficient, so I thought I'd open a PR for it.