### PR TITLE
driver/sqlite3: Fix for upstream changes

### DIFF
--- a/driver/sqlite3/sqlite3.go
+++ b/driver/sqlite3/sqlite3.go
@@ -92,7 +92,7 @@ func (driver *Driver) Migrate(f file.File, pipe chan interface{}) {
 	}
 
 	if _, err := tx.Exec(string(f.Content)); err != nil {
-		sqliteErr, isErr := err.(sqlite3.Error)
+		sqliteErr, isErr := err.(*sqlite3.Error)
 
 		if isErr {
 			// The sqlite3 library only provides error codes, not position information. Output what we do know


### PR DESCRIPTION
It appears the sqlite3 lib has made breaking commits for this package:

https://github.com/mattn/go-sqlite3/commit/cf4bd560f1588d96c502b4c3407fe1a10cef4a28
https://github.com/mattn/go-sqlite3/commit/bd7fdb60336d54a68de20c03df2a036848e89eca

I was getting the following when trying to `go get` this tool:
```
go get -u github.com/mattes/migrate
# github.com/mattes/migrate/driver/sqlite3
../.go_workspace/src/github.com/mattes/migrate/driver/sqlite3/sqlite3.go:95: impossible type assertion:
	sqlite3.Error does not implement error (Error method has pointer receiver)

go get -u github.com/mattes/migrate returned exit code 2

Action failed: go get -u github.com/mattes/migrate
```

Simple fix, change type assertion to use a pointer.