### PR TITLE
fixing error cast for sqlite3

### DIFF
--- a/driver/sqlite3/sqlite3.go
+++ b/driver/sqlite3/sqlite3.go
@@ -92,7 +92,7 @@ func (driver *Driver) Migrate(f file.File, pipe chan interface{}) {
 	}
 
 	if _, err := tx.Exec(string(f.Content)); err != nil {
-		sqliteErr, isErr := err.(*sqlite3.Error)
+		sqliteErr, isErr := err.(sqlite3.Error)
 
 		if isErr {
 			// The sqlite3 library only provides error codes, not position information. Output what we do know


### PR DESCRIPTION
Seems the sqlite3 packaged reverted to using non-pointer Error. This patch corrects the use of it here.

This resolves issue #188 