### PR TITLE
Support for alternative postgres URI scheme

### DIFF
--- a/driver/postgres/postgres.go
+++ b/driver/postgres/postgres.go
@@ -139,5 +139,7 @@ func (driver *Driver) Version() (uint64, error) {
 }
 
 func init() {
-	driver.RegisterDriver("postgres", &Driver{})
+	drv := Driver{}
+	driver.RegisterDriver("postgres", &drv)
+	driver.RegisterDriver("postgresql", &drv)
 }


### PR DESCRIPTION
According to the PostgreSQL documentation (section 32.1.1.2), postgres library supports two URI schemes: postgresql:// and postgres://

Reference:
https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING