### PR TITLE
Support for alternative postgres URI scheme

### DIFF
--- a/database/postgres/postgres.go
+++ b/database/postgres/postgres.go
@@ -13,7 +13,9 @@ import (
 )
 
 func init() {
-	database.Register("postgres", &Postgres{})
+	db := Postgres{}
+	database.Register("postgres", &db)
+	database.Register("postgresql", &db)
 }
 
 var DefaultMigrationsTable = "schema_migrations"


### PR DESCRIPTION
According to the PostgreSQL documentation (section 32.1.1.2), postgres library supports two URI schemes: postgresql:// and postgres://

Reference:
https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING