### PR TITLE
Return a new instance of Driver from registry's GetDriver() function

### DIFF
--- a/driver/bash/bash.go
+++ b/driver/bash/bash.go
@@ -32,5 +32,5 @@ func (driver *Driver) Version() (uint64, error) {
 }
 
 func init() {
-	driver.RegisterDriver("bash", &Driver{})
+	driver.RegisterDriver("bash", Driver{})
 }

--- a/driver/cassandra/cassandra.go
+++ b/driver/cassandra/cassandra.go
@@ -178,7 +178,7 @@ func (driver *Driver) Version() (uint64, error) {
 }
 
 func init() {
-	driver.RegisterDriver("cassandra", &Driver{})
+	driver.RegisterDriver("cassandra", Driver{})
 }
 
 // ParseConsistency wraps gocql.ParseConsistency to return an error

--- a/driver/crate/crate.go
+++ b/driver/crate/crate.go
@@ -13,7 +13,7 @@ import (
 )
 
 func init() {
-	driver.RegisterDriver("crate", &Driver{})
+	driver.RegisterDriver("crate", Driver{})
 }
 
 type Driver struct {

--- a/driver/mongodb/mongodb.go
+++ b/driver/mongodb/mongodb.go
@@ -56,7 +56,7 @@ func (d *Driver) SetMethodsReceiver(r interface{}) error {
 }
 
 func init() {
-	driver.RegisterDriver("mongodb", &Driver{})
+	driver.RegisterDriver("mongodb", Driver{})
 }
 
 type DbMigration struct {

--- a/driver/mysql/mysql.go
+++ b/driver/mysql/mysql.go
@@ -181,5 +181,5 @@ func (driver *Driver) Version() (uint64, error) {
 }
 
 func init() {
-	driver.RegisterDriver("mysql", &Driver{})
+	driver.RegisterDriver("mysql", Driver{})
 }

--- a/driver/neo4j/neo4j.go
+++ b/driver/neo4j/neo4j.go
@@ -162,5 +162,5 @@ func (driver *Driver) Version() (uint64, error) {
 }
 
 func init() {
-	driver.RegisterDriver("neo4j", &Driver{})
+	driver.RegisterDriver("neo4j", Driver{})
 }

--- a/driver/postgres/postgres.go
+++ b/driver/postgres/postgres.go
@@ -140,6 +140,6 @@ func (driver *Driver) Version() (uint64, error) {
 
 func init() {
 	drv := Driver{}
-	driver.RegisterDriver("postgres", &drv)
-	driver.RegisterDriver("postgresql", &drv)
+	driver.RegisterDriver("postgres", drv)
+	driver.RegisterDriver("postgresql", drv)
 }

--- a/driver/ql/ql.go
+++ b/driver/ql/ql.go
@@ -126,6 +126,6 @@ func (d *Driver) ensureVersionTableExists() error {
 }
 
 func init() {
-	driver.RegisterDriver("ql+file", &Driver{})
-	driver.RegisterDriver("ql+memory", &Driver{})
+	driver.RegisterDriver("ql+file", Driver{})
+	driver.RegisterDriver("ql+memory", Driver{})
 }

--- a/driver/sqlite3/sqlite3.go
+++ b/driver/sqlite3/sqlite3.go
@@ -127,5 +127,5 @@ func (driver *Driver) Version() (uint64, error) {
 }
 
 func init() {
-	driver.RegisterDriver("sqlite3", &Driver{})
+	driver.RegisterDriver("sqlite3", Driver{})
 }


### PR DESCRIPTION
I've found that concurrent migrations on multiple schema are not possible due to the fact that GetDriver() returns a Driver singleton for all named drivers. There are definitely more sound ways to solve this (i.e. registering a factory method to create a customized new instance of Driver), but given the simplicity of the current design, I've opted to just create and return a new instance of Driver from GetDriver() by using the reflect package.

I've tested this using the MySQL driver specifically and am now able to run concurrent migrations on any number of unique database URLs.