### PR TITLE
Date-based versions

### DIFF
--- a/source/parse.go
+++ b/source/parse.go
@@ -24,7 +24,7 @@ var Regex = regexp.MustCompile(`^([0-9]+)_(.*)\.(` + string(Down) + `|` + string
 func Parse(raw string) (*Migration, error) {
 	m := Regex.FindStringSubmatch(raw)
 	if len(m) == 5 {
-		versionUint64, err := strconv.ParseUint(m[1], 10, 32)
+		versionUint64, err := strconv.ParseUint(m[1], 10, 64)
 		if err != nil {
 			return nil, err
 		}

--- a/source/parse_test.go
+++ b/source/parse_test.go
@@ -51,6 +51,16 @@ func TestParse(t *testing.T) {
 			},
 		},
 		{
+			name:      "20170412214116_date_foobar.up.sql",
+			expectErr: nil,
+			expectMigration: &Migration{
+				Version:    20170412214116,
+				Identifier: "date_foobar",
+				Direction:  Up,
+				Raw:        "20170412214116_date_foobar.up.sql",
+			},
+		},
+		{
 			name:            "-1_foobar.up.sql",
 			expectErr:       ErrParse,
 			expectMigration: nil,


### PR DESCRIPTION
Hi, 

Thank you for your work on this useful library,

I bumped into an issue when trying to use a date-based version (coming from a rails background) like "20170412214116_create_foo.up.sql" because a uint 32 is not enough to hold that number.

It's up to you if you think this is a valid golang use case, am just a newbie learning idiomatic go.