### PR TITLE
Fix appending multiStatements=true parameter for mysql driver

### DIFF
--- a/database/mysql/mysql.go
+++ b/database/mysql/mysql.go
@@ -85,7 +85,9 @@ func (m *Mysql) Open(url string) (database.Driver, error) {
 		return nil, err
 	}
 
-	purl.Query().Set("multiStatements", "true")
+	q := purl.Query()
+	q.Set("multiStatements", "true")
+	purl.RawQuery = q.Encode()
 
 	db, err := sql.Open("mysql", strings.Replace(
 		migrate.FilterCustomQuery(purl).String(), "mysql://", "", 1))


### PR DESCRIPTION
Current mysql driver does not support multiple SQL statements in a single migration unless user manually sets `multiStatements=true` parameter in database DSN when **migrate** tool is executed.

Driver code tries to override this parameter to always be true but the parameter value is never saved back to the url struct.

This PR fixes this minor issue.