### PR TITLE
Fix a typo in go-bindata/README.md

### DIFF
--- a/source/go-bindata/README.md
+++ b/source/go-bindata/README.md
@@ -15,7 +15,7 @@ cd examples/migrations && go-bindata -pkg migrations .
 import (
   "github.com/mattes/migrate"
   "github.com/mattes/migrate/source/go-bindata"
-  "github.com/mattes/migrate/source/go-bindata/examples/migrations
+  "github.com/mattes/migrate/source/go-bindata/examples/migrations"
 )
 
 func main() {


### PR DESCRIPTION
I was browsing this and noticed the typo that is causing syntax highlighting to be off.