### PR TITLE
Add missing import to example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ import (
     _ "github.com/lib/pq"
     "github.com/mattes/migrate"
     "github.com/mattes/migrate/database/postgres"
+    _ "github.com/mattes/migrate/source/file"
 )
 
 func main() {


### PR DESCRIPTION
The example in README with file source doesn't work without importing "github.com/mattes/migrate/source/file" package.