### PR TITLE
Register neo4j driver using a pseudo `neo4js` protocol scheme.

### DIFF
--- a/driver/neo4j/neo4j.go
+++ b/driver/neo4j/neo4j.go
@@ -163,4 +163,5 @@ func (driver *Driver) Version() (uint64, error) {
 
 func init() {
 	driver.RegisterDriver("neo4j", &Driver{})
+	driver.RegisterDriver("neo4js", &Driver{})
 }


### PR DESCRIPTION
Neo4J supports both `http` and `https` connections, however `https`
connections weren't supported previously as the `neo4j` URL scheme
currently used to identify the driver type is always substituted for
just `http`.

This PR also registers the driver under an alternate key: `neo4js` which
given the way the scheme substitution happens, should allow the driver
to correctly create an `https` connection URL. This will allow the
library to be used for cases where we don't have access to the plain
`http` endpoint.