### PR TITLE
Added support for Redshift.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 __Database migrations written in Go. Use as [CLI](#cli-usage) or import as [library](#use-in-your-go-project).__
 
- * Migrate reads migrations from [sources](#migration-sources) 
+ * Migrate reads migrations from [sources](#migration-sources)
    and applies them in correct order to a [database](#databases).
  * Drivers are "dumb", migrate glues everything together and makes sure the logic is bulletproof.  
    (Keeps the drivers lightweight, too.)
@@ -17,11 +17,12 @@ __Database migrations written in Go. Use as [CLI](#cli-usage) or import as [libr
 Looking for [v1](https://github.com/mattes/migrate/tree/v1)?
 
 
-## Databases 
+## Databases
 
 Database drivers run migrations. [Add a new database?](database/driver.go)
 
   * [PostgreSQL](database/postgres)
+  * [Redshift](database/redshift)
   * [Cassandra](database/cassandra) ([todo #164](https://github.com/mattes/migrate/issues/164))
   * [SQLite](database/sqlite) ([todo #165](https://github.com/mattes/migrate/issues/165))
   * [MySQL/ MariaDB](database/mysql)
@@ -46,7 +47,7 @@ Source drivers read migrations from local or remote sources. [Add a new source?]
 
 
 
-## CLI usage 
+## CLI usage
 
   * Simple wrapper around this library.
   * Handles ctrl+c (SIGINT) gracefully.
@@ -57,12 +58,12 @@ __[CLI Documentation](cli)__
 ([brew todo #156](https://github.com/mattes/migrate/issues/156))
 
 ```
-$ brew install migrate --with-postgres 
+$ brew install migrate --with-postgres
 $ migrate -database postgres://localhost:5432/database up 2
 ```
 
 
-## Use in your Go project 
+## Use in your Go project
 
  * API is stable and frozen for this release (v3.x).
  * Package migrate has no external dependencies.

--- a/cli/build_redshift.go
+++ b/cli/build_redshift.go
@@ -1,0 +1,7 @@
+// +build redshift
+
+package main
+
+import (
+	_ "github.com/mattes/migrate/database/redshift"
+)

--- a/database/redshift/README.md
+++ b/database/redshift/README.md
@@ -1,0 +1,6 @@
+Redshift
+===
+
+This provides a Redshift driver for migrations.  It is used whenever the URL of the database starts with `redshift://`.
+
+Redshift is PostgreSQL compatible but has some specific features (or lack thereof) that require slightly different behavior.

--- a/database/redshift/redshift.go
+++ b/database/redshift/redshift.go
@@ -1,0 +1,46 @@
+package redshift
+
+import (
+	"net/url"
+
+	"github.com/mattes/migrate/database"
+	"github.com/mattes/migrate/database/postgres"
+)
+
+// init registers the driver under the name 'redshift'
+func init() {
+	db := new(Redshift)
+	db.Driver = new(postgres.Postgres)
+
+	database.Register("redshift", db)
+}
+
+// Redshift is a wrapper around the PostgreSQL driver which implements Redshift-specific behavior.
+//
+// Currently, the only different behaviour is the lack of locking in Redshift.  The (Un)Lock() method(s) have been overridden from the PostgreSQL adapter to simply return nil.
+type Redshift struct {
+	// The wrapped PostgreSQL driver.
+	database.Driver
+}
+
+// Open implements the database.Driver interface by parsing the URL, switching the scheme from "redshift" to "postgres", and delegating to the underlying PostgreSQL driver.
+func (driver *Redshift) Open(dsn string) (database.Driver, error) {
+	parsed, err := url.Parse(dsn)
+	if err != nil {
+		return nil, err
+	}
+
+	parsed.Scheme = "postgres"
+	psql, err := driver.Driver.Open(parsed.String())
+	if err != nil {
+		return nil, err
+	}
+
+	return &Redshift{Driver: psql}, nil
+}
+
+// Lock implements the database.Driver interface by not locking and returning nil.
+func (driver *Redshift) Lock() error { return nil }
+
+// Unlock implements the database.Driver interface by not unlocking and returning nil.
+func (driver *Redshift) Unlock() error { return nil }


### PR DESCRIPTION
While Redshift is wire compatible with PostgreSQL, they support different functionality internally. 
 Due to its distributed nature and being an OLAP database instead of a OLTP, Redshift does not in general support locking.

The upgraded PostgreSQL driver uses `pg_try_advisory_lock` in the `Lock()` and `Unlock()` functions, which is not supported by Redshift and causes and error.  This adds a Redshift-specific driver that wraps the standard PostgreSQL driver and overrides the `Lock()` and `Unlock()` to simply return `nil`.