### PR TITLE
Add command to make CLI example with Go toolchain work

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -6,6 +6,7 @@
 
 ```
 $ go get -u -d github.com/mattes/migrate/cli
+$ go get github.com/lib/pq
 $ go build -tags 'postgres' -o /usr/local/bin/migrate github.com/mattes/migrate/cli
 ```
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -5,8 +5,7 @@
 #### With Go toolchain
 
 ```
-$ go get -u -d github.com/mattes/migrate/cli
-$ go get github.com/lib/pq
+$ go get -u -d github.com/mattes/migrate/cli github.com/lib/pq
 $ go build -tags 'postgres' -o /usr/local/bin/migrate github.com/mattes/migrate/cli
 ```
 


### PR DESCRIPTION
If the Go Postgres driver is not installed, then the example will fail. This commit adds the missing command.