### PR TITLE
Solve lock contention problem when upgrading multiple logical MySQL databases backed by a single physical database.

### DIFF
--- a/database/mysql/mysql.go
+++ b/database/mysql/mysql.go
@@ -156,7 +156,8 @@ func (m *Mysql) Lock() error {
 		return database.ErrLocked
 	}
 
-	aid, err := database.GenerateAdvisoryLockId(m.config.DatabaseName)
+	aid, err := database.GenerateAdvisoryLockId(
+		fmt.Sprintf("%s:%s", m.config.DatabaseName, m.config.MigrationsTable)
 	if err != nil {
 		return err
 	}
@@ -180,7 +181,8 @@ func (m *Mysql) Unlock() error {
 		return nil
 	}
 
-	aid, err := database.GenerateAdvisoryLockId(m.config.DatabaseName)
+	aid, err := database.GenerateAdvisoryLockId(
+		fmt.Sprintf("%s:%s", m.config.DatabaseName, m.config.MigrationsTable)
 	if err != nil {
 		return err
 	}

--- a/database/mysql/mysql.go
+++ b/database/mysql/mysql.go
@@ -157,7 +157,7 @@ func (m *Mysql) Lock() error {
 	}
 
 	aid, err := database.GenerateAdvisoryLockId(
-		fmt.Sprintf("%s:%s", m.config.DatabaseName, m.config.MigrationsTable)
+		fmt.Sprintf("%s:%s", m.config.DatabaseName, m.config.MigrationsTable))
 	if err != nil {
 		return err
 	}
@@ -182,7 +182,7 @@ func (m *Mysql) Unlock() error {
 	}
 
 	aid, err := database.GenerateAdvisoryLockId(
-		fmt.Sprintf("%s:%s", m.config.DatabaseName, m.config.MigrationsTable)
+		fmt.Sprintf("%s:%s", m.config.DatabaseName, m.config.MigrationsTable))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
In MySQL driver, lock name is purely determined by the database name.  However, it is quite common that multiple logical databases are physically backed by one single physical database. To make such logically isolated database migration work, we can specify different migration table for different logical database. The only problem is: migrating them in parallel will fail if another migrater holds the lock.

This change is to let lock name uses both database name and migration table name.