### PR TITLE
Fix error due to duplicate schema version table for Spanner

### DIFF
--- a/database/spanner/spanner.go
+++ b/database/spanner/spanner.go
@@ -258,7 +258,7 @@ func (s *Spanner) Drop() error {
 func (s *Spanner) ensureVersionTable() error {
 	ctx := context.Background()
 	tbl := s.config.MigrationsTable
-	iter := s.db.data.Single().Read(ctx, tbl, spanner.AllKeys(), nil)
+	iter := s.db.data.Single().Read(ctx, tbl, spanner.AllKeys(), []string{"Version"})
 	if err := iter.Do(func(r *spanner.Row) error { return nil }); err == nil {
 		return nil
 	}


### PR DESCRIPTION
I've got following message from the second time migration for Spanner.

```
2017/06/24 16:51:01 rpc error: code = InvalidArgument desc = Duplicate name in schema: SchemaMigrations. in line 0: CREATE TABLE SchemaMigrations (
    Version INT64 NOT NULL,
    Dirty    BOOL NOT NULL
        ) PRIMARY KEY(Version)
exit status 1
```

That's because not given existing column names causes `Invalid StreamingRead request` error in Spanner client and it is mistaken that the schema version table does not exist.
