### PR TITLE
Update docker dependency version to fix Tavis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ services:
 
 install:
   - make deps
-  - (cd $GOPATH/src/github.com/docker/docker && git fetch --all --tags --prune && git checkout v1.13.0)
-  - sudo apt-get update && sudo apt-get install docker-engine=1.13.0*
+  - (cd $GOPATH/src/github.com/docker/docker && git fetch --all --tags --prune && git checkout v17.05.0-ce)
+  - sudo apt-get update && sudo apt-get install docker-ce=17.05.0*
   - go get github.com/mattn/goveralls 
 
 script:


### PR DESCRIPTION
Tavis has updated its docker images, and as part of the update,
no longer includes support for the (deprevated) docker-engine
package, moving instead to docker-ce.

See https://blog.travis-ci.com/2017-06-21-trusty-updates-2017-Q2-launch
for details of the package change.

This updates the travis configuration to pin the docker library
version to 17.05.0 and installs the corresponding version of
docker-ce in the install script.