### PR TITLE
feat(mysql): try creating database if not exist

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -3,10 +3,10 @@ package main
 import (
 	"flag"
 	"fmt"
-	"strings"
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 

--- a/database/cassandra/cassandra.go
+++ b/database/cassandra/cassandra.go
@@ -21,8 +21,8 @@ var DefaultMigrationsTable = "schema_migrations"
 var dbLocked = false
 
 var (
-	ErrNilConfig = fmt.Errorf("no config")
-	ErrNoKeyspace = fmt.Errorf("no keyspace provided")
+	ErrNilConfig     = fmt.Errorf("no config")
+	ErrNoKeyspace    = fmt.Errorf("no keyspace provided")
 	ErrDatabaseDirty = fmt.Errorf("database is dirty")
 )
 
@@ -36,7 +36,7 @@ type Cassandra struct {
 	isLocked bool
 
 	// Open and WithInstance need to guarantee that config is never nil
-	config   *Config
+	config *Config
 }
 
 func (p *Cassandra) Open(url string) (database.Driver, error) {
@@ -154,7 +154,6 @@ func (p *Cassandra) SetVersion(version int, dirty bool) error {
 	return nil
 }
 
-
 // Return current keyspace version
 func (p *Cassandra) Version() (version int, dirty bool, err error) {
 	query := `SELECT version, dirty FROM "` + p.config.MigrationsTable + `" LIMIT 1`
@@ -192,7 +191,6 @@ func (p *Cassandra) Drop() error {
 	return nil
 }
 
-
 // Ensure version table exists
 func (p *Cassandra) ensureVersionTable() error {
 	err := p.session.Query(fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (version bigint, dirty boolean, PRIMARY KEY(version))", p.config.MigrationsTable)).Exec()
@@ -204,7 +202,6 @@ func (p *Cassandra) ensureVersionTable() error {
 	}
 	return nil
 }
-
 
 // ParseConsistency wraps gocql.ParseConsistency
 // to return an error instead of a panicking.

--- a/database/cassandra/cassandra.go
+++ b/database/cassandra/cassandra.go
@@ -112,7 +112,7 @@ func (p *Cassandra) Close() error {
 }
 
 func (p *Cassandra) Lock() error {
-	if (dbLocked) {
+	if dbLocked {
 		return database.ErrLocked
 	}
 	dbLocked = true

--- a/database/cassandra/cassandra.go
+++ b/database/cassandra/cassandra.go
@@ -5,10 +5,11 @@ import (
 	"io"
 	"io/ioutil"
 	nurl "net/url"
-	"github.com/gocql/gocql"
-	"time"
-	"github.com/mattes/migrate/database"
 	"strconv"
+	"time"
+
+	"github.com/gocql/gocql"
+	"github.com/mattes/migrate/database"
 )
 
 func init() {


### PR DESCRIPTION
**Background:** Our scenario is that we'd like to be able to create schema
from scratch for a brand new staging environment. This new staging
environment doesn't have the database created.

**Problem:** Having a first migration doing `CREATE DATABASE xxx` doesn't
work because a connection to `mysql://tcp(a.b.c.d)/xxx` fails when database
driver is trying to switch to the database `xxx`.

**Proposed solution:** When `Open(...)`ing a MySQL `Driver`, we always try
to create the database if it doesn't exist and _then_ we reestablish a new
database connection and ask the MySQL `database/sql/driver.Driver` to make
the switch to the database.