### PR TITLE
feat(cassandra): support for multistatement migrations

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -3,10 +3,10 @@ package main
 import (
 	"flag"
 	"fmt"
-	"strings"
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 

--- a/database/cassandra/README.md
+++ b/database/cassandra/README.md
@@ -1,11 +1,11 @@
 # Cassandra
 
-* Drop command will not work on Cassandra 2.X because it rely on
-system_schema table which comes with 3.X
-* Other commands should work properly but are **not tested**
-
+* Drop command will not work on Cassandra 2.X because it rely on system_schema
+  table which comes with 3.X.
+* Other commands should work properly but are **not tested**.
 
 ## Usage
+
 `cassandra://host:port/keyspace?param1=value&param2=value2`
 
 
@@ -16,7 +16,6 @@ system_schema table which comes with 3.X
 | `consistency` | ALL | Migration consistency
 | `protocol` |  | Cassandra protocol version (3 or 4)
 | `timeout` | 1 minute | Migration timeout
-
 
 `timeout` is parsed using [time.ParseDuration(s string)](https://golang.org/pkg/time/#ParseDuration)
 

--- a/database/cassandra/README.md
+++ b/database/cassandra/README.md
@@ -19,6 +19,20 @@
 
 `timeout` is parsed using [time.ParseDuration(s string)](https://golang.org/pkg/time/#ParseDuration)
 
+## Multistatement migrations
+
+If you would like to execute multiple statements in a single migration, you can
+prepend the migration file with `# migrate:oneLinePerQuery`. Note that each statement must then be situation on a single line. Example migration:
+
+```
+# migrate:oneLinePerQuery
+
+# Demo users for european market:
+INSERT TO users(username) VALUES ("eurodemo");
+
+# Demo users for US market:
+INSERT TO users(username) VALUES ("usdemo");
+```
 
 ## Upgrading from v1
 

--- a/database/cassandra/cassandra.go
+++ b/database/cassandra/cassandra.go
@@ -21,8 +21,8 @@ var DefaultMigrationsTable = "schema_migrations"
 var dbLocked = false
 
 var (
-	ErrNilConfig = fmt.Errorf("no config")
-	ErrNoKeyspace = fmt.Errorf("no keyspace provided")
+	ErrNilConfig     = fmt.Errorf("no config")
+	ErrNoKeyspace    = fmt.Errorf("no keyspace provided")
 	ErrDatabaseDirty = fmt.Errorf("database is dirty")
 )
 
@@ -36,7 +36,7 @@ type Cassandra struct {
 	isLocked bool
 
 	// Open and WithInstance need to guarantee that config is never nil
-	config   *Config
+	config *Config
 }
 
 func (p *Cassandra) Open(url string) (database.Driver, error) {
@@ -154,7 +154,6 @@ func (p *Cassandra) SetVersion(version int, dirty bool) error {
 	return nil
 }
 
-
 // Return current keyspace version
 func (p *Cassandra) Version() (version int, dirty bool, err error) {
 	query := `SELECT version, dirty FROM "` + p.config.MigrationsTable + `" LIMIT 1`
@@ -192,7 +191,6 @@ func (p *Cassandra) Drop() error {
 	return nil
 }
 
-
 // Ensure version table exists
 func (p *Cassandra) ensureVersionTable() error {
 	err := p.session.Query(fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (version bigint, dirty boolean, PRIMARY KEY(version))", p.config.MigrationsTable)).Exec()
@@ -204,7 +202,6 @@ func (p *Cassandra) ensureVersionTable() error {
 	}
 	return nil
 }
-
 
 // ParseConsistency wraps gocql.ParseConsistency
 // to return an error instead of a panicking.

--- a/database/cassandra/cassandra.go
+++ b/database/cassandra/cassandra.go
@@ -112,7 +112,7 @@ func (p *Cassandra) Close() error {
 }
 
 func (p *Cassandra) Lock() error {
-	if (dbLocked) {
+	if dbLocked {
 		return database.ErrLocked
 	}
 	dbLocked = true

--- a/database/cassandra/cassandra.go
+++ b/database/cassandra/cassandra.go
@@ -5,10 +5,11 @@ import (
 	"io"
 	"io/ioutil"
 	nurl "net/url"
-	"github.com/gocql/gocql"
-	"time"
-	"github.com/mattes/migrate/database"
 	"strconv"
+	"time"
+
+	"github.com/gocql/gocql"
+	"github.com/mattes/migrate/database"
 )
 
 func init() {


### PR DESCRIPTION
Unfortunately [1] doesn't support multiple semicolon-separated queries, so
they must be executed individually. While this isn't perfect, it covers a
lot of cases where one would like to executed multiple statements in a
single migration.

[1] https://godoc.org/github.com/gocql/gocql#Session.Query