### PR TITLE
(Spanner) Add support for multiple statements in one migration step

### DIFF
--- a/database/spanner/spanner.go
+++ b/database/spanner/spanner.go
@@ -137,12 +137,12 @@ func (s *Spanner) Run(migration io.Reader) error {
 	}
 
 	// run migration
-	stmt := string(migr[:])
+	stmts := migrationStatements(migr)
 	ctx := context.Background()
 
 	op, err := s.db.admin.UpdateDatabaseDdl(ctx, &adminpb.UpdateDatabaseDdlRequest{
 		Database:   s.config.DatabaseName,
-		Statements: []string{stmt},
+		Statements: stmts,
 	})
 
 	if err != nil {
@@ -281,4 +281,14 @@ func (s *Spanner) ensureVersionTable() error {
 	}
 
 	return nil
+}
+
+func migrationStatements(migration []byte) []string {
+	regex := regexp.MustCompile(";$")
+	migrationString := string(migration[:])
+	migrationString = strings.TrimSpace(migrationString)
+	migrationString = regex.ReplaceAllString(migrationString, "")
+
+	statements := strings.Split(migrationString, ";")
+	return statements
 }


### PR DESCRIPTION
### Proposed Change:
Support migration steps with multiple statements.

### Current Behavior:
Migration steps with multiple statements currently fail with an error like `Syntax error on line x, column x: Expecting \'EOF\' but found an unknown character (\";\")`

**Example of a migration that currently fails:**
```SQL
CREATE TABLE table_name (
    id STRING(255) NOT NULL,
) PRIMARY KEY(id);

CREATE INDEX table_name_id_idx ON table_name (id);
```