### PR TITLE
Change GracefulStop into a RO channel

### DIFF
--- a/migrate.go
+++ b/migrate.go
@@ -62,7 +62,7 @@ type Migrate struct {
 	// GracefulStop accepts `true` and will stop executing migrations
 	// as soon as possible at a safe break point, so that the database
 	// is not corrupted.
-	GracefulStop   chan bool
+	GracefulStop   <-chan bool
 	isGracefulStop bool
 
 	isLockedMu *sync.Mutex


### PR DESCRIPTION
Migrate never writes to the GracefulStop channel, so why not guarantee that by turning the chan into a ReadOnly channel?

In my case I already had such a channel available which happened to be RO, so for me it wasn't just a nice to have, but sort of a necessity :)

I believe this change does not break BC.