### PR TITLE
Fix Docker install on TravisCi by allowing the docker-ce package to be downgraded

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ services:
 install:
   - make deps
   - (cd $GOPATH/src/github.com/docker/docker && git fetch --all --tags --prune && git checkout v17.05.0-ce)
-  - sudo apt-get update && sudo apt-get install docker-ce=17.05.0*
+  - sudo apt-get update && sudo apt-get --allow-downgrades install docker-ce=17.05.0*
   - go get github.com/mattn/goveralls 
 
 script:


### PR DESCRIPTION
* Started happening since TravisCI updated docker-ce https://docs.travis-ci.com/user/build-environment-updates/2017-12-12/
* Can't use v17.09 since the git tag doesn't exist yet