### PR TITLE
Made source.Up and source.Down the same type

### DIFF
--- a/source/migration.go
+++ b/source/migration.go
@@ -9,7 +9,7 @@ type Direction string
 
 const (
 	Down Direction = "down"
-	Up             = "up"
+	Up   Direction = "up"
 )
 
 // Migration is a helper struct for source drivers that need to


### PR DESCRIPTION
Changed source.Up from being an untyped string const to being a typed source.Direction const. This makes source.Up and source.Down the same type.