### PR TITLE
add option to choose a timestamp format for migration files

### DIFF
--- a/cli/commands.go
+++ b/cli/commands.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 )
 
-func createCmd(dir string, timestamp int64, name string, ext string) {
+func createCmd(dir string, timestamp interface{}, name string, ext string) {
 	base := fmt.Sprintf("%v%v_%v.", dir, timestamp, name)
 	os.MkdirAll(dir, os.ModePerm)
 	createFile(base + "up" + ext)

--- a/cli/main.go
+++ b/cli/main.go
@@ -42,8 +42,9 @@ Options:
   -help            Print usage
 
 Commands:
-  create [-ext E] [-dir D] NAME
+  create [-ext E] [-dir D] [-timestamp unix] NAME
                Create a set of timestamped up/down migrations titled NAME, in directory D with extension E
+               -timestamp accepts "unix" for Unix timestamps (e.g. 1516205943) and "datetime" or "time" for datetime timestamps (e.g. 180117181903), default: "unix"
   goto V       Migrate to version V
   up [N]       Apply all or N up migrations
   down [N]     Apply all or N down migrations
@@ -110,6 +111,7 @@ Commands:
 		createFlagSet := flag.NewFlagSet("create", flag.ExitOnError)
 		extPtr := createFlagSet.String("ext", "", "File extension")
 		dirPtr := createFlagSet.String("dir", "", "Directory to place file in (default: current working directory)")
+		timestampFormatPtr := createFlagSet.String("timestamp", "unix", `Format of a timestamp ("unix" for Unix timestamp, "datetime" or "time" for datetime timestamp, default: "unix")`)
 		createFlagSet.Parse(args)
 
 		if createFlagSet.NArg() == 0 {
@@ -124,7 +126,13 @@ Commands:
 			*dirPtr = strings.Trim(*dirPtr, "/") + "/"
 		}
 
-		timestamp := startTime.Unix()
+		var timestamp interface{}
+
+		if *timestampFormatPtr == "datetime" || *timestampFormatPtr == "time" {
+			timestamp = startTime.Format("060102150405")
+		} else {
+			timestamp = startTime.Unix()
+		}
 
 		createCmd(*dirPtr, timestamp, name, *extPtr)
 


### PR DESCRIPTION
Currently the Unix timestamp is the only option while generating migration files. This PR adds an option to choose a datetime format for the migration timestamp.

I have added the `-timestamp` option for `create` action:
```
migrate create -timestamp time migration_name
```

For example, for Jan 18th 2018, 18:19:03 the datetime migration timestamp will be `180117181903`, while the standard Unix timestamp will be `1516205943`.

In some cases, datetime timestamps are more convenient to work with. If `-timestamp` flag is not supplied, the default Unix timestamp will be used.

