### PR TITLE
fix mysql test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ services:
 install:
   - make deps
   - (cd $GOPATH/src/github.com/docker/docker && git fetch --all --tags --prune && git checkout v17.05.0-ce)
-  - sudo apt-get update && sudo apt-get install docker-ce=17.05.0*
+  - sudo apt-get update && sudo apt-get --allow-downgrades install docker-ce=17.05.0*
   - go get github.com/mattn/goveralls 
 
 script:

--- a/database/mysql/mysql_test.go
+++ b/database/mysql/mysql_test.go
@@ -11,6 +11,7 @@ import (
 	// "github.com/go-sql-driver/mysql"
 	dt "github.com/mattes/migrate/database/testing"
 	mt "github.com/mattes/migrate/testing"
+	"time"
 )
 
 var versions = []mt.Version{
@@ -42,6 +43,7 @@ func Test(t *testing.T) {
 		func(t *testing.T, i mt.Instance) {
 			p := &Mysql{}
 			addr := fmt.Sprintf("mysql://root:root@tcp(%v:%v)/public", i.Host(), i.Port())
+			time.Sleep(time.Second * 15) // it seems that sometimes MySQL server is not started yet and the test fails
 			d, err := p.Open(addr)
 			if err != nil {
 				t.Fatalf("%v", err)


### PR DESCRIPTION
Sometimes MySQL test would fail apparently because MySQL Server on Docker would start after the test tried to connect to it. This can be fixed with a delay in the test.