### PR TITLE
Remove mentions to https://github.com/jteeuwen/go-bindata

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Database drivers run migrations. [Add a new database?](database/driver.go)
 Source drivers read migrations from local or remote sources. [Add a new source?](source/driver.go)
 
   * [Filesystem](source/file) - read from fileystem
-  * [Go-Bindata](source/go-bindata) - read from embedded binary data ([jteeuwen/go-bindata](https://github.com/jteeuwen/go-bindata))
+  * [Go-Bindata](source/go-bindata) - read from embedded binary data ([kevinburke/go-bindata](https://github.com/kevinburke/go-bindata))
   * [Github](source/github) - read from remote Github repositories
   * [AWS S3](source/aws-s3) - read from Amazon Web Services S3
   * [Google Cloud Storage](source/google-cloud-storage) - read from Google Cloud Platform Storage

--- a/source/go-bindata/README.md
+++ b/source/go-bindata/README.md
@@ -7,7 +7,7 @@
 ### Read bindata with NewWithSourceInstance
 
 ```shell
-go get -u github.com/jteeuwen/go-bindata/...
+go get -u github.com/kevinburke/go-bindata/...
 cd examples/migrations && go-bindata -pkg migrations .
 ```
 


### PR DESCRIPTION
in favor of an active maintained one at https://github.com/kevinburke/go-bindata with clear intentions.

Fixes #333