### PR TITLE
Added a generic git source and unit tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ cli/cli
 cli/migrate
 .coverage
 .godoc.pid
+.idea
+cover.out

--- a/source/git/README.md
+++ b/source/git/README.md
@@ -1,0 +1,25 @@
+# git
+
+A generic Git backend source that can be used with services such a GitHub and BitBucket.
+
+`ssh://user@host/owner/repo/path[?ssh-key-path=/home/user/key]`
+
+| URL Query  | WithInstance Config | Description |
+|------------|---------------------|-------------|
+| ssh-key-path | | the path to an ssh private key on your local disk |
+| user | | the user to authenticate with when using ssh |
+| owner | | the repo owner |
+| repo | | the name of the repository |
+| path | Config.Path | path in repo to migrations |
+
+\* If no `ssh-key-path` parameter is passed then migrate will attempt to use `id_rsa` or `id_dsa` stored in your homes `.ssh` folder.
+
+`https://[user][:password]@host/owner/repo/path`
+
+| URL Query  | WithInstance Config | Description |
+|------------|---------------------|-------------|
+| user | | the user to authenticate with when using ssh |
+| password | | the password to use when authenticating as user |
+| owner | | the repo owner |
+| repo | | the name of the repository |
+| path | Config.Path | path in repo to migrations |

--- a/source/git/git.go
+++ b/source/git/git.go
@@ -10,10 +10,10 @@ import (
 	"os"
 
 	"github.com/mattes/migrate/source"
-	"github.com/src-d/go-git/plumbing/transport"
-	"gopkg.in/src-d/go-billy.v3/memfs"
+	"gopkg.in/src-d/go-billy.v4/memfs"
 	"gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/transport"
 	githttp "gopkg.in/src-d/go-git.v4/plumbing/transport/http"
 	gitssh "gopkg.in/src-d/go-git.v4/plumbing/transport/ssh"
 	"gopkg.in/src-d/go-git.v4/storage/memory"
@@ -217,7 +217,7 @@ func NewRepository(url string) (*git.Repository, string, error) {
 
 		gitURL, err = m.URL()
 		if m.User != "" {
-			gitAuth = githttp.NewBasicAuth(m.User, m.Password)
+			gitAuth = &githttp.BasicAuth{Username: m.User, Password: m.Password}
 		}
 	}
 

--- a/source/git/git.go
+++ b/source/git/git.go
@@ -193,16 +193,19 @@ func NewRepository(url string) (*git.Repository, string, error) {
 
 		gitURL, err = m.URL()
 
-		for _, cert := range m.Certs {
+		for i, cert := range m.Certs {
 
 			b, err := ioutil.ReadFile(cert)
 			if err != nil {
+				if i+1 == len(m.Certs){
+					return nil, "", errNoValidCerts
+				}
 				continue
 			}
 
 			signer, err := ssh.ParsePrivateKey(b)
 			if err != nil {
-				continue
+				return nil, "", err
 			}
 
 			gitAuth = &gitssh.PublicKeys{

--- a/source/git/git.go
+++ b/source/git/git.go
@@ -1,0 +1,378 @@
+package git
+
+import (
+	"errors"
+	"fmt"
+	"golang.org/x/crypto/ssh"
+	"io"
+	"io/ioutil"
+	nurl "net/url"
+	"os"
+
+	"github.com/mattes/migrate/source"
+	"github.com/src-d/go-git/plumbing/transport"
+	"gopkg.in/src-d/go-billy.v3/memfs"
+	"gopkg.in/src-d/go-git.v4"
+	"gopkg.in/src-d/go-git.v4/plumbing"
+	githttp "gopkg.in/src-d/go-git.v4/plumbing/transport/http"
+	gitssh "gopkg.in/src-d/go-git.v4/plumbing/transport/ssh"
+	"gopkg.in/src-d/go-git.v4/storage/memory"
+	"strings"
+)
+
+const (
+	paramSSHKeyPath = "ssh-key-path"
+	envHome         = "HOME"
+	schemeSSH       = "ssh"
+	schemeHTTPS     = "https"
+)
+
+var (
+	errNoValidCerts       = errors.New("no valid ssh certificate could be loaded")
+	errInvalidURL         = errors.New("invalid url")
+	errSchemeNotSupported = errors.New("scheme not supported")
+	errUserMissing        = errors.New("user is required")
+	errOwnerMissing       = errors.New("owner is required")
+	errRepoMissing        = errors.New("repo is required")
+	errHostMissing        = errors.New("host is required")
+)
+
+func init() {
+	source.Register("git", &Git{})
+}
+
+// Git is the underlying struct used by the source driver.
+type Git struct {
+	path       string
+	repo       *git.Repository
+	migrations *source.Migrations
+}
+
+// Config can be passed in when using with instance.
+type Config struct {
+	Path string
+}
+
+// RepoMeta is the struct which gets populated from the parsed in git url.
+type RepoMeta struct {
+	Scheme   string
+	Owner    string
+	User     string
+	Password string
+	Repo     string
+	Path     string
+	Host     string
+	Certs    []string
+}
+
+// FullRepoName will return the full "owner/repo" name based on the values stored in the repo meta struct. If one
+// of the dependent values are missing an error is returned.
+func (m *RepoMeta) FullRepoName() (string, error) {
+
+	if m.Owner == "" {
+		return "", errOwnerMissing
+	}
+
+	if m.Repo == "" {
+		return "", errRepoMissing
+	}
+
+	return fmt.Sprintf("%v/%v", m.Owner, m.Repo), nil
+}
+
+// URL will return the url based on the the repo metas scheme value. If the scheme is not supported an error will be
+// returned.
+func (m *RepoMeta) URL() (string, error) {
+
+	fullRepoName, err := m.FullRepoName()
+	if err != nil {
+		return "", err
+	}
+
+	if m.Host == "" {
+		return "", errHostMissing
+	}
+
+	switch m.Scheme {
+	case schemeSSH:
+		return fmt.Sprintf("%v@%v:%v", m.User, m.Host, fullRepoName), nil
+
+	case schemeHTTPS:
+		return fmt.Sprintf("https://%v/%v", m.Host, fullRepoName), nil
+	}
+
+	return "", errSchemeNotSupported
+}
+
+// Validate is used to validate the repo meta struct.
+func (m *RepoMeta) Validate() error {
+
+	switch m.Scheme {
+	case schemeSSH:
+		if m.User == "" {
+			return errUserMissing
+		}
+
+	case schemeHTTPS:
+
+	default:
+		return errSchemeNotSupported
+	}
+
+	if m.Host == "" {
+		return errHostMissing
+	}
+
+	if m.Owner == "" {
+		return errOwnerMissing
+	}
+
+	if m.Repo == "" {
+		return errRepoMissing
+	}
+
+	return nil
+}
+
+// Parse is used to read in the url and stores the information in the url to a repo meta struct.
+func Parse(url string) (*RepoMeta, error) {
+
+	u, err := nurl.Parse(url)
+	if err != nil {
+		return nil, err
+	}
+
+	parts := strings.Split(u.Path, "/")
+	if len(parts) < 3 {
+		return nil, errInvalidURL
+	}
+
+	m := RepoMeta{
+		Scheme: u.Scheme,
+		Owner:  parts[1],
+		Repo:   parts[2],
+		Path:   strings.Join(parts[3:], "/"),
+		Host:   u.Host,
+	}
+
+	m.Certs = u.Query()[paramSSHKeyPath]
+	m.Certs = append(
+		m.Certs,
+		fmt.Sprintf("%v/.ssh/id_rsa", os.Getenv(envHome)),
+		fmt.Sprintf("%v/.ssh/id_dsa", os.Getenv(envHome)),
+	)
+
+	if u.User != nil {
+		m.User = u.User.Username()
+		m.Password, _ = u.User.Password()
+	}
+
+	err = m.Validate()
+	if err != nil {
+		return nil, err
+	}
+
+	return &m, nil
+}
+
+// NewRepository is used to return a new get repository, repo path or an error if any errors are encountered whist
+// creating the git repository client.
+func NewRepository(url string) (*git.Repository, string, error) {
+
+	m, err := Parse(url)
+	if err != nil {
+		return nil, "", err
+	}
+
+	var gitAuth transport.AuthMethod
+	var gitURL string
+
+	switch m.Scheme {
+	case schemeSSH:
+
+		gitURL, err = m.URL()
+
+		for _, cert := range m.Certs {
+
+			b, err := ioutil.ReadFile(cert)
+			if err != nil {
+				continue
+			}
+
+			signer, err := ssh.ParsePrivateKey(b)
+			if err != nil {
+				continue
+			}
+
+			gitAuth = &gitssh.PublicKeys{
+				User:   m.User,
+				Signer: signer,
+			}
+
+			break
+		}
+
+	case schemeHTTPS:
+
+		gitURL, err = m.URL()
+		if m.User != "" {
+			gitAuth = githttp.NewBasicAuth(m.User, m.Password)
+		}
+	}
+
+	fs := memfs.New()
+
+	r, err := git.Clone(memory.NewStorage(), fs, &git.CloneOptions{
+		URL:  gitURL,
+		Auth: gitAuth,
+	})
+
+	return r, m.Path, nil
+}
+
+// Open is used to return a source driver based on the url string passed.
+func (g *Git) Open(url string) (source.Driver, error) {
+
+	repo, path, err := NewRepository(url)
+	if err != nil {
+		return nil, err
+	}
+
+	gn := &Git{
+		repo:       repo,
+		path:       path,
+		migrations: source.NewMigrations(),
+	}
+
+	if err := gn.readDirectory(); err != nil {
+		return nil, err
+	}
+
+	return gn, nil
+}
+
+// WithInstance is used to pass in an existing git repo instance. A config must also be passed to include any of the
+// required configs.
+func WithInstance(repo *git.Repository, config *Config) (source.Driver, error) {
+
+	gn := &Git{
+		repo:       repo,
+		path:       config.Path,
+		migrations: source.NewMigrations(),
+	}
+	if err := gn.readDirectory(); err != nil {
+		return nil, err
+	}
+	return gn, nil
+}
+
+func (g *Git) readDirectory() error {
+
+	w, err := g.repo.Worktree()
+	if err != nil {
+		return err
+	}
+
+	w.Checkout(&git.CheckoutOptions{
+		Hash: plumbing.NewHash(""),
+	})
+
+	fullPath := fmt.Sprintf("/%s", g.path)
+
+	_, err = w.Filesystem.Stat(fullPath)
+	if err != nil {
+		return err
+	}
+
+	files, err := w.Filesystem.ReadDir(fullPath)
+	if err != nil {
+		return err
+	}
+
+	for _, fi := range files {
+
+		if fi.IsDir() {
+			continue
+		}
+
+		m, err := source.DefaultParse(fi.Name())
+		if err != nil {
+			continue
+		}
+
+		if !g.migrations.Append(m) {
+			return fmt.Errorf("unable to parse file %v", fi.Name())
+		}
+	}
+
+	return nil
+}
+
+// Close is used to close the connection to the git repository.
+func (g *Git) Close() error {
+	return nil
+}
+
+// First is used to return the first migration version encountered.
+func (g *Git) First() (version uint, er error) {
+	if v, ok := g.migrations.First(); !ok {
+		return 0, &os.PathError{"first", g.path, os.ErrNotExist}
+	} else {
+		return v, nil
+	}
+}
+
+// Prev is used to return the previous migration version.
+func (g *Git) Prev(version uint) (prevVersion uint, err error) {
+	if v, ok := g.migrations.Prev(version); !ok {
+		return 0, &os.PathError{fmt.Sprintf("prev for version %v", version), g.path, os.ErrNotExist}
+	} else {
+		return v, nil
+	}
+}
+
+// Next is used to return the next migration version.
+func (g *Git) Next(version uint) (nextVersion uint, err error) {
+	if v, ok := g.migrations.Next(version); !ok {
+		return 0, &os.PathError{fmt.Sprintf("next for version %v", version), g.path, os.ErrNotExist}
+	} else {
+		return v, nil
+	}
+}
+
+// ReadUp reads in the next migration.
+func (g *Git) ReadUp(version uint) (r io.ReadCloser, identifier string, err error) {
+
+	if m, ok := g.migrations.Up(version); ok {
+		w, err := g.repo.Worktree()
+		if err != nil {
+			return nil, "", err
+		}
+
+		f, err := w.Filesystem.Open(fmt.Sprintf("/%s/%s", g.path, m.Raw))
+		if err != nil {
+			return nil, "", err
+		}
+
+		return f, m.Identifier, nil
+	}
+	return nil, "", &os.PathError{fmt.Sprintf("read version %v", version), g.path, os.ErrNotExist}
+}
+
+// ReadDown reads in the previous migration.
+func (g *Git) ReadDown(version uint) (r io.ReadCloser, identifier string, err error) {
+	if m, ok := g.migrations.Down(version); ok {
+		w, err := g.repo.Worktree()
+		if err != nil {
+			return nil, "", err
+		}
+
+		f, err := w.Filesystem.Open(fmt.Sprintf("/%s/%s", g.path, m.Raw))
+		if err != nil {
+			return nil, "", err
+		}
+
+		return f, m.Identifier, nil
+	}
+	return nil, "", &os.PathError{fmt.Sprintf("read version %v", version), g.path, os.ErrNotExist}
+}

--- a/source/git/git.go
+++ b/source/git/git.go
@@ -38,7 +38,8 @@ var (
 )
 
 func init() {
-	source.Register("git", &Git{})
+	source.Register("ssh", &Git{})
+	source.Register("https", &Git{})
 }
 
 // Git is the underlying struct used by the source driver.

--- a/source/git/git_test.go
+++ b/source/git/git_test.go
@@ -3,7 +3,7 @@ package git
 import (
 	"fmt"
 	st "github.com/mattes/migrate/source/testing"
-	"gopkg.in/src-d/go-billy.v3/memfs"
+	"gopkg.in/src-d/go-billy.v4/memfs"
 	"gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/storage/memory"
 	"os"

--- a/source/git/git_test.go
+++ b/source/git/git_test.go
@@ -1,0 +1,289 @@
+package git
+
+import (
+	"fmt"
+	st "github.com/mattes/migrate/source/testing"
+	"gopkg.in/src-d/go-billy.v3/memfs"
+	"gopkg.in/src-d/go-git.v4"
+	"gopkg.in/src-d/go-git.v4/storage/memory"
+	"os"
+	"regexp"
+	"testing"
+)
+
+const (
+	urlHTTP                     = "https://github.com/mattes/migrate_test.git/test"
+	urlSSH                      = "ssh://git@github.com/mattes/migrate_test.git/test"
+	urlSSHWithoutPath           = "ssh://git@github.com/mattes/migrate_test.git"
+	urlSSHWithBadPath           = "ssh://git@github.com/mattes/migrate_test.git/foobar"
+	urlHTTPWithBadPath          = "https://github.com/mattes/migrate_test.git/foobar"
+	urlInvalidSSH               = "ssh://github.com/mattes/migrate_test.git"
+	urlValidHTTP                = "https://github.com/mattes/migrate_test.git"
+	urlValidHTTPWithUser        = "https://joe@github.com/mattes/migrate_test.git"
+	urlValidHTTPWithUserAndPass = "https://joe:shhh@github.com/mattes/migrate_test.git"
+	urlValidSSH                 = "ssh://joe@github.com/mattes/migrate_test.git?ssh-key-path="
+	urlInvalidSchemeProtocol    = ":foo.bar"
+	urlInvalidSchemeType        = "foo://foo.bar/mattes/migrate_test.git"
+	urlInvalid                  = "foo.bar"
+	schemeUnsupported           = "unsupported"
+	valueOwner                  = "mattes"
+	valueRepo                   = "migrate_test.git"
+	valueHost                   = "github.com"
+	valueUser                   = "git"
+)
+
+func newRepo() (*git.Repository, error) {
+
+	fs := memfs.New()
+
+	r, err := git.Clone(memory.NewStorage(), fs, &git.CloneOptions{
+		URL: urlSSHWithoutPath,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+func TestViaSSH(t *testing.T) {
+	b := &Git{}
+	d, err := b.Open(urlSSH)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	st.Test(t, d)
+}
+
+func TestViaHTTP(t *testing.T) {
+	b := &Git{}
+	d, err := b.Open(urlHTTP)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	st.Test(t, d)
+}
+
+func TestWithInstance(t *testing.T) {
+
+	vr, err := newRepo()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := Config{}
+
+	testCases := []struct {
+		Expect error
+		Repo   *git.Repository
+	}{
+		{Repo: &git.Repository{}, Expect: git.ErrIsBareRepository},
+		{Repo: vr},
+	}
+
+	for i, tc := range testCases {
+		_, err := WithInstance(tc.Repo, &cfg)
+		if err != tc.Expect {
+			t.Error(caseNumber(i, haveWant(err, tc.Expect)))
+		}
+	}
+}
+
+func TestRepoMeta_FullRepoName(t *testing.T) {
+
+	testCases := []struct {
+		Meta       RepoMeta
+		Expect     error
+		ExpectName string
+	}{
+		{Meta: RepoMeta{}, Expect: errOwnerMissing},
+		{Meta: RepoMeta{Owner: valueOwner}, Expect: errRepoMissing},
+		{Meta: RepoMeta{Owner: valueOwner, Repo: valueRepo}, ExpectName: fmt.Sprintf("%v/%v", valueOwner, valueRepo)},
+	}
+
+	for _, tc := range testCases {
+		name, err := tc.Meta.FullRepoName()
+		if err != tc.Expect {
+			t.Error(haveWant(err, tc.Expect))
+		}
+		if name != tc.ExpectName {
+			t.Error(haveWant(name, tc.ExpectName))
+		}
+	}
+}
+
+func TestRepoMeta_URL(t *testing.T) {
+
+	testCases := []struct {
+		Meta       RepoMeta
+		Expect     error
+		ExpectName string
+	}{
+		{Meta: RepoMeta{}, Expect: errOwnerMissing},
+		{Meta: RepoMeta{Owner: valueOwner}, Expect: errRepoMissing},
+		{Meta: RepoMeta{Owner: valueOwner, Repo: valueRepo}, Expect: errHostMissing},
+		{Meta: RepoMeta{Owner: valueOwner, Repo: valueRepo, Scheme: schemeSSH}, Expect: errHostMissing},
+		{Meta: RepoMeta{Owner: valueOwner, Repo: valueRepo, Scheme: schemeHTTPS}, Expect: errHostMissing},
+		{Meta: RepoMeta{Owner: valueOwner, Repo: valueRepo, Host: valueHost}, Expect: errSchemeNotSupported},
+		{Meta: RepoMeta{Owner: valueOwner, Repo: valueRepo, Host: valueHost, Scheme: schemeUnsupported}, Expect: errSchemeNotSupported},
+	}
+
+	for i, tc := range testCases {
+		url, err := tc.Meta.URL()
+		if err != tc.Expect {
+			t.Error(label("error", caseNumber(i, haveWant(err, tc.Expect))))
+		}
+		if url != tc.ExpectName {
+			t.Error(label("url", caseNumber(i, haveWant(url, tc.ExpectName))))
+		}
+	}
+}
+
+func TestRepoMeta_Validate(t *testing.T) {
+
+	testCases := []struct {
+		Meta   RepoMeta
+		Expect error
+	}{
+		{Expect: errSchemeNotSupported},
+		{Expect: errUserMissing, Meta: RepoMeta{Scheme: schemeSSH}},
+		{Expect: errOwnerMissing, Meta: RepoMeta{Scheme: schemeSSH, User: valueUser, Host: valueHost}},
+		{Expect: errRepoMissing, Meta: RepoMeta{Scheme: schemeSSH, User: valueUser, Host: valueHost, Owner: valueOwner}},
+		{Meta: RepoMeta{Scheme: schemeSSH, User: valueUser, Host: valueHost, Owner: valueOwner, Repo: valueRepo}},
+		{Expect: errHostMissing, Meta: RepoMeta{Scheme: schemeHTTPS}},
+		{Expect: errOwnerMissing, Meta: RepoMeta{Scheme: schemeHTTPS, Host: valueHost}},
+		{Expect: errRepoMissing, Meta: RepoMeta{Scheme: schemeHTTPS, Host: valueHost, Owner: valueOwner}},
+		{Meta: RepoMeta{Scheme: schemeHTTPS, Host: valueHost, Owner: valueOwner, Repo: valueRepo}},
+	}
+
+	for i, tc := range testCases {
+
+		if have, want := tc.Meta.Validate(), tc.Expect; have != want {
+			t.Error(caseNumber(i, haveWant(have, want)))
+		}
+	}
+
+}
+
+func TestParse(t *testing.T) {
+
+	testCases := []struct {
+		URL        string
+		Expect     string
+		ExpectMeta *RepoMeta
+	}{
+		{Expect: "missing protocol scheme", URL: urlInvalidSchemeProtocol},
+		{Expect: errInvalidURL.Error(), URL: urlInvalid},
+		{Expect: errUserMissing.Error(), URL: urlInvalidSSH},
+		{URL: urlValidHTTP, ExpectMeta: &RepoMeta{Scheme: schemeHTTPS, Host: valueHost, Owner: valueOwner, Repo: valueRepo}},
+		{URL: urlValidHTTPWithUser},
+		{URL: urlValidHTTPWithUserAndPass},
+		{URL: urlValidSSH},
+	}
+
+	for i, tc := range testCases {
+		meta, err := Parse(tc.URL)
+		if !isError(err, tc.Expect) {
+			t.Error(label("error", caseNumber(i, haveWant(err, tc.Expect))))
+		}
+		if meta != nil && tc.ExpectMeta != nil {
+			if meta.Scheme != tc.ExpectMeta.Scheme {
+				t.Error(label("meta scheme", caseNumber(i, haveWant(meta.Scheme, tc.ExpectMeta.Scheme))))
+			}
+			if meta.Host != tc.ExpectMeta.Host {
+				t.Error(label("meta host", caseNumber(i, haveWant(meta.Host, tc.ExpectMeta.Host))))
+			}
+			if meta.User != tc.ExpectMeta.User {
+				t.Error(label("meta user", caseNumber(i, haveWant(meta.User, tc.ExpectMeta.User))))
+			}
+			if meta.Password != tc.ExpectMeta.Password {
+				t.Error(label("meta password", caseNumber(i, haveWant(meta.Password, tc.ExpectMeta.Password))))
+			}
+			if meta.Owner != tc.ExpectMeta.Owner {
+				t.Error(label("meta owner", caseNumber(i, haveWant(meta.Owner, tc.ExpectMeta.Owner))))
+			}
+			if meta.Repo != tc.ExpectMeta.Repo {
+				t.Error(label("meta repo", caseNumber(i, haveWant(meta.Repo, tc.ExpectMeta.Repo))))
+			}
+		}
+	}
+}
+
+func TestNewRepository(t *testing.T) {
+
+	testCases := []struct {
+		URL        string
+		Expect     error
+		ExpectPath string
+	}{
+		{URL: urlInvalid, Expect: errInvalidURL},
+		{URL: urlValidHTTP},
+		{URL: urlValidHTTPWithUser},
+		{URL: urlValidHTTPWithUserAndPass},
+		{URL: urlValidSSH},
+		{Expect: errSchemeNotSupported, URL: urlInvalidSchemeType},
+	}
+
+	for i, tc := range testCases {
+		_, path, err := NewRepository(tc.URL)
+		if err != tc.Expect {
+			t.Error(label("error", caseNumber(i, haveWant(err, tc.Expect))))
+		}
+		if path != tc.ExpectPath {
+			t.Error(label("path", caseNumber(i, haveWant(path, tc.ExpectPath))))
+		}
+	}
+}
+
+func TestGit_Open(t *testing.T) {
+
+	testCases := []struct {
+		URL    string
+		Expect error
+	}{
+		{URL: urlInvalid, Expect: errInvalidURL},
+		{URL: urlSSH},
+		{URL: urlHTTP},
+		{URL: urlHTTPWithBadPath, Expect: os.ErrNotExist},
+		{URL: urlSSHWithBadPath, Expect: os.ErrNotExist},
+	}
+
+	g := &Git{}
+
+	for i, tc := range testCases {
+		_, err := g.Open(tc.URL)
+		if err != tc.Expect {
+			t.Error(caseNumber(i, haveWant(err, tc.Expect)))
+		}
+	}
+
+}
+
+func label(label string, message string) string {
+	return fmt.Sprintf("%s: %s", label, message)
+}
+
+func caseNumber(index int, message string) string {
+	return fmt.Sprintf("test case :%v: %v", index+1, message)
+}
+
+func haveWant(have, want interface{}) string {
+	return fmt.Sprintf("an unexpected result was returned (have: %v, want: %v)", have, want)
+}
+
+func isError(err error, re string) bool {
+	if err == nil && re == "" {
+		return true
+	}
+	if err == nil || re == "" {
+		return false
+	}
+	matched, mErr := regexp.MatchString(re, err.Error())
+	if mErr != nil {
+		return false
+	}
+	return matched
+}


### PR DESCRIPTION
Hi @mattes,

I hope you don't mind me raising this PR but I recently had a go at creating a more generic git source that can be used with other vendors other than GitHub. The reason for this was I found myself continually writing checkout wrappers so I could use the filesystem source but it was proofing to be do painful. So thought I would have an attempt at creating a source driver. I ended up using go-git's in memory capabilities and I also added the ability to specify the location of git ssh keys via a http param. Please have a look and provide any feedback. If you like what you see. I am more than happy for you to merge this.

More info can be found in the readme.

Kind regards,
Justin