### PR TITLE
Handle container failure when container is nil

### DIFF
--- a/testing/testing.go
+++ b/testing/testing.go
@@ -41,7 +41,11 @@ func ParallelTest(t *testing.T, versions []Version, readyFn IsReadyFunc, testFn 
 				// create new container
 				container, err := NewDockerContainer(t, version.Image, version.ENV, version.Cmd)
 				if err != nil {
-					t.Fatalf("%v\n%s", err, containerLogs(t, container))
+					if container == nil {
+						t.Fatal(err)
+					} else {
+						t.Fatalf("%v\n%s", err, containerLogs(t, container))
+					}
 				}
 
 				// make sure to remove container once done


### PR DESCRIPTION
If there is an error and the returned container is nil, `containerLogs` panics. This branches to ensure `containerLogs` isn't called with `nil`.